### PR TITLE
Portfolio rebuild: design tokens, sections, command palette, polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ next-env.d.ts
 .idea
 
 .vscode
+.superpowers/

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,0 +1,1 @@
+# SDD Progress — playful-portfolio rebuild

--- a/.superpowers/sdd/progress.md
+++ b/.superpowers/sdd/progress.md
@@ -1,1 +1,0 @@
-# SDD Progress — playful-portfolio rebuild

--- a/package.json
+++ b/package.json
@@ -8,9 +8,12 @@
     "lint": "next lint --fix"
   },
   "dependencies": {
-    "@material-tailwind/react": "^2.1.9",
     "@vercel/analytics": "^1.3.1",
+    "canvas-confetti": "^1.9.4",
+    "cmdk": "^1.1.1",
+    "lenis": "^1.3.25",
     "lucide-react": "^0.378.0",
+    "motion": "^12.42.2",
     "next": "^14.2.5",
     "next-themes": "^0.3.0",
     "normalize.css": "^8.0.1",
@@ -18,6 +21,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@types/canvas-confetti": "^1.9.0",
     "@types/node": "22.2.0",
     "@types/react": "18.3.3",
     "autoprefixer": "10.4.20",

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,1 @@
-{"name":"Escaleira Portfolio","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{"name":"Escaleira Portfolio","short_name":"","icons":[],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,5 +1,6 @@
 import { KeyboardEvent, useEffect, useRef, useState } from "react";
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, useCommandState } from "cmdk";
+import { scrollToSection } from "@/components/SmoothScroll";
 import { projects } from "@/data/projects";
 
 const GITHUB_URL = "https://github.com/MarcoEscaleira";
@@ -15,10 +16,6 @@ const SECTION_COMMANDS: { id: string; label: string; description: string }[] = [
   { id: "skills", label: "skills", description: "tools of the trade" },
   { id: "contact", label: "contact", description: "say hello" },
 ];
-
-const scrollToSection = (id: string) => {
-  document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
-};
 
 const openInNewTab = (href: string) => {
   window.open(href, "_blank", "noreferrer");
@@ -144,6 +141,7 @@ export const CommandPalette = ({ open, onOpenChange }: Props) => {
       onOpenChange={onOpenChange}
       label="Command palette"
       shouldFilter
+      vimBindings={false}
       contentClassName="fixed left-1/2 top-24 z-[101] w-full max-w-xl -translate-x-1/2 overflow-hidden rounded-lg border border-border bg-surface font-mono shadow-2xl shadow-black/20"
       overlayClassName="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm"
     >
@@ -270,7 +268,7 @@ export const CommandPalette = ({ open, onOpenChange }: Props) => {
             PaletteInput; onSelect here covers a mouse click on Enter's
             focus-selected row in the rare case the item is visible via
             keyword search debugging. */}
-        <CommandGroup>
+        <CommandGroup value="hidden">
           <CommandItem value="sudo" onSelect={runSudo} className="hidden" keywords={["sudo"]} />
           <CommandItem value="konami" onSelect={runKonami} className="hidden" keywords={["konami"]} />
           <CommandItem value="motojoy" onSelect={runMotojoy} className="hidden" keywords={["motojoy"]} />

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -1,0 +1,288 @@
+import { KeyboardEvent, useEffect, useRef, useState } from "react";
+import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList, useCommandState } from "cmdk";
+import { projects } from "@/data/projects";
+
+const GITHUB_URL = "https://github.com/MarcoEscaleira";
+const LINKEDIN_URL = "https://www.linkedin.com/in/marco-escaleira00/";
+const EMAIL = "marcoescaleira2000@gmail.com";
+const CV_PATH = "/Marco-Escaleira-CV.pdf";
+
+const SECTION_COMMANDS: { id: string; label: string; description: string }[] = [
+  { id: "home", label: "home", description: "back to the top" },
+  { id: "about", label: "about", description: "who I am" },
+  { id: "projects", label: "projects", description: "things I've built" },
+  { id: "experience", label: "experience", description: "where I've worked" },
+  { id: "skills", label: "skills", description: "tools of the trade" },
+  { id: "contact", label: "contact", description: "say hello" },
+];
+
+const scrollToSection = (id: string) => {
+  document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+};
+
+const openInNewTab = (href: string) => {
+  window.open(href, "_blank", "noreferrer");
+};
+
+type Props = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+type PaletteInputProps = {
+  search: string;
+  onSearchChange: (value: string) => void;
+  onUnknownSubmit: (value: string) => void;
+  exactCommands: Record<string, () => void>;
+};
+
+/**
+ * Wraps CommandInput so we can read cmdk's live filtered-item count via
+ * useCommandState (only available inside the Command root) and fire the
+ * "command not found" output when Enter is pressed with zero matches.
+ *
+ * Exact hidden-command matches (sudo/konami/motojoy) are resolved here
+ * directly rather than relying on cmdk's fuzzy ranking + auto-selected item:
+ * a full, exact match like "sudo" can otherwise lose the highlighted/Enter
+ * slot to an unrelated visible item whose letters fuzzy-match the same
+ * sequence (e.g. "shouldYouDoIt" contains s-u-d-o in order).
+ */
+const PaletteInput = ({ search, onSearchChange, onUnknownSubmit, exactCommands }: PaletteInputProps) => {
+  const filteredCount = useCommandState(state => state.filtered.count);
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== "Enter") return;
+    const value = search.trim();
+    if (!value) return;
+
+    const exactMatch = exactCommands[value.toLowerCase()];
+    if (exactMatch) {
+      event.preventDefault();
+      exactMatch();
+      return;
+    }
+
+    if (filteredCount > 0) return;
+    onUnknownSubmit(value);
+  };
+
+  return (
+    <CommandInput
+      value={search}
+      onValueChange={onSearchChange}
+      onKeyDown={handleKeyDown}
+      placeholder="type a command… (try 'help')"
+      className="w-full bg-transparent text-sm text-fg placeholder:text-fg-muted focus:outline-none"
+    />
+  );
+};
+
+export const CommandPalette = ({ open, onOpenChange }: Props) => {
+  const [search, setSearch] = useState("");
+  const [output, setOutput] = useState<string | null>(null);
+  const triggerRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      // cmdk's Dialog doesn't expose a Trigger, so capture whatever had
+      // focus (hotkey target or the Hero/404 chip) ourselves and restore it
+      // when the palette closes.
+      triggerRef.current = document.activeElement as HTMLElement | null;
+      return undefined;
+    }
+
+    setSearch("");
+    setOutput(null);
+    triggerRef.current?.focus?.();
+    triggerRef.current = null;
+    return undefined;
+  }, [open]);
+
+  const close = () => onOpenChange(false);
+
+  const runNavigate = (id: string) => {
+    scrollToSection(id);
+    close();
+  };
+
+  const runWhoami = () => {
+    setOutput("Marco Escaleira — full-stack engineer, London");
+  };
+
+  const runHelp = () => {
+    const commandNames = SECTION_COMMANDS.map(c => c.label)
+      .concat(["whoami", "cv", "github", "linkedin", "email", "help"])
+      .join(", ");
+    setOutput(`available commands: ${commandNames}`);
+  };
+
+  const runSudo = () => {
+    setOutput("permission denied: nice try, you are not root here");
+  };
+
+  const runKonami = () => {
+    setOutput("hint: ↑ ↑ ↓ ↓ ← → ← → B A — try it on the page, not in here");
+  };
+
+  const runMotojoy = () => {
+    setOutput("MotoJoy: PHP, jQuery, and Bootstrap — my e-commerce origin story. See it in the projects section.");
+  };
+
+  const runUnknown = (value: string) => {
+    setOutput(`command not found: ${value} — try 'help'`);
+  };
+
+  const exactCommands: Record<string, () => void> = {
+    sudo: runSudo,
+    konami: runKonami,
+    motojoy: runMotojoy,
+  };
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      label="Command palette"
+      shouldFilter
+      contentClassName="fixed left-1/2 top-24 z-[101] w-full max-w-xl -translate-x-1/2 overflow-hidden rounded-lg border border-border bg-surface font-mono shadow-2xl shadow-black/20"
+      overlayClassName="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm"
+    >
+      <div className="flex items-center gap-2 border-b border-border px-4 py-3">
+        <span className="text-accent">❯</span>
+        <PaletteInput
+          search={search}
+          onSearchChange={setSearch}
+          onUnknownSubmit={runUnknown}
+          exactCommands={exactCommands}
+        />
+      </div>
+
+      <CommandList className="max-h-80 overflow-y-auto p-2">
+        <CommandEmpty className="px-3 py-6 text-sm text-fg-muted">
+          command not found: {search || "?"} — try &lsquo;help&rsquo; (press Enter)
+        </CommandEmpty>
+
+        <CommandGroup
+          heading="navigate"
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-fg-muted"
+        >
+          {SECTION_COMMANDS.map(({ id, label, description }) => (
+            <CommandItem
+              key={id}
+              value={label}
+              onSelect={() => runNavigate(id)}
+              className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+            >
+              <span>{label}</span>
+              <span className="text-xs text-fg-muted">{description}</span>
+            </CommandItem>
+          ))}
+        </CommandGroup>
+
+        <CommandGroup
+          heading="actions"
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-fg-muted"
+        >
+          <CommandItem
+            value="whoami"
+            onSelect={runWhoami}
+            className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+          >
+            <span>whoami</span>
+            <span className="text-xs text-fg-muted">who is this, anyway</span>
+          </CommandItem>
+          <CommandItem
+            value="cv"
+            onSelect={() => {
+              openInNewTab(CV_PATH);
+              close();
+            }}
+            className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+          >
+            <span>cv</span>
+            <span className="text-xs text-fg-muted">open my CV</span>
+          </CommandItem>
+          <CommandItem
+            value="github"
+            onSelect={() => {
+              openInNewTab(GITHUB_URL);
+              close();
+            }}
+            className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+          >
+            <span>github</span>
+            <span className="text-xs text-fg-muted">github.com/MarcoEscaleira</span>
+          </CommandItem>
+          <CommandItem
+            value="linkedin"
+            onSelect={() => {
+              openInNewTab(LINKEDIN_URL);
+              close();
+            }}
+            className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+          >
+            <span>linkedin</span>
+            <span className="text-xs text-fg-muted">connect on LinkedIn</span>
+          </CommandItem>
+          <CommandItem
+            value="email"
+            onSelect={() => {
+              window.location.href = `mailto:${EMAIL}`;
+              close();
+            }}
+            className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+          >
+            <span>email</span>
+            <span className="text-xs text-fg-muted">{EMAIL}</span>
+          </CommandItem>
+          <CommandItem
+            value="help"
+            onSelect={runHelp}
+            className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+          >
+            <span>help</span>
+            <span className="text-xs text-fg-muted">list available commands</span>
+          </CommandItem>
+        </CommandGroup>
+
+        {projects.length > 0 && (
+          <CommandGroup
+            heading="projects"
+            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:uppercase [&_[cmdk-group-heading]]:tracking-wide [&_[cmdk-group-heading]]:text-fg-muted"
+          >
+            {projects.map(project => (
+              <CommandItem
+                key={project.slug}
+                value={project.title}
+                onSelect={() => runNavigate("projects")}
+                className="flex cursor-pointer items-center justify-between rounded-md px-3 py-2 text-sm text-fg data-[selected=true]:bg-bg data-[selected=true]:text-accent"
+              >
+                <span>{project.title}</span>
+                <span className="truncate pl-4 text-xs text-fg-muted">{project.tagline}</span>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+
+        {/* Hidden commands: never listed, but still registered so cmdk counts
+            them as matches (keeps CommandEmpty from showing) when typed
+            exactly. Enter-on-exact-match is handled directly in
+            PaletteInput; onSelect here covers a mouse click on Enter's
+            focus-selected row in the rare case the item is visible via
+            keyword search debugging. */}
+        <CommandGroup>
+          <CommandItem value="sudo" onSelect={runSudo} className="hidden" keywords={["sudo"]} />
+          <CommandItem value="konami" onSelect={runKonami} className="hidden" keywords={["konami"]} />
+          <CommandItem value="motojoy" onSelect={runMotojoy} className="hidden" keywords={["motojoy"]} />
+        </CommandGroup>
+      </CommandList>
+
+      {output && (
+        <div className="border-t border-border bg-bg px-4 py-3 text-sm text-fg-muted">
+          <span className="mr-2 text-accent">$</span>
+          {output}
+        </div>
+      )}
+    </CommandDialog>
+  );
+};

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -261,18 +261,6 @@ export const CommandPalette = ({ open, onOpenChange }: Props) => {
             ))}
           </CommandGroup>
         )}
-
-        {/* Hidden commands: never listed, but still registered so cmdk counts
-            them as matches (keeps CommandEmpty from showing) when typed
-            exactly. Enter-on-exact-match is handled directly in
-            PaletteInput; onSelect here covers a mouse click on Enter's
-            focus-selected row in the rare case the item is visible via
-            keyword search debugging. */}
-        <CommandGroup value="hidden">
-          <CommandItem value="sudo" onSelect={runSudo} className="hidden" keywords={["sudo"]} />
-          <CommandItem value="konami" onSelect={runKonami} className="hidden" keywords={["konami"]} />
-          <CommandItem value="motojoy" onSelect={runMotojoy} className="hidden" keywords={["motojoy"]} />
-        </CommandGroup>
       </CommandList>
 
       {output && (

--- a/src/components/EasterEggs.tsx
+++ b/src/components/EasterEggs.tsx
@@ -75,17 +75,25 @@ export const EasterEggs = () => {
   }, [toast]);
 
   useEffect(() => {
-    const originalTitle = document.title;
+    let titleBeforeHide: string | null = null;
 
     const handleVisibilityChange = () => {
-      document.title = document.hidden ? AWAY_TITLE : originalTitle;
+      if (document.hidden) {
+        titleBeforeHide = document.title;
+        document.title = AWAY_TITLE;
+      } else if (titleBeforeHide !== null) {
+        document.title = titleBeforeHide;
+        titleBeforeHide = null;
+      }
     };
 
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       document.removeEventListener("visibilitychange", handleVisibilityChange);
-      document.title = originalTitle;
+      if (titleBeforeHide !== null) {
+        document.title = titleBeforeHide;
+      }
     };
   }, []);
 

--- a/src/components/EasterEggs.tsx
+++ b/src/components/EasterEggs.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import confetti from "canvas-confetti";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const KONAMI_SEQUENCE = [
+  "ArrowUp",
+  "ArrowUp",
+  "ArrowDown",
+  "ArrowDown",
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowLeft",
+  "ArrowRight",
+  "b",
+  "a",
+];
+
+const AWAY_TITLE = "👋 come back soon — marco";
+
+const fireConfetti = () => {
+  const accent = getComputedStyle(document.documentElement).getPropertyValue("--color-accent").trim();
+  const colorFromRgbTriplet = accent ? `rgb(${accent.replace(/\s+/g, ", ")})` : undefined;
+
+  confetti({
+    particleCount: 140,
+    spread: 80,
+    origin: { y: 0.6 },
+    colors: colorFromRgbTriplet ? [colorFromRgbTriplet, "#ffffff"] : undefined,
+  });
+};
+
+/**
+ * Renders nothing by default. Listens for the Konami code (fires confetti +
+ * a toast, or a text-only toast under reduced motion) and swaps the tab
+ * title to a playful message while the tab is hidden.
+ */
+export const EasterEggs = () => {
+  const shouldReduceMotion = useReducedMotion();
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    let progress = 0;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const expected = KONAMI_SEQUENCE[progress];
+      const key = event.key.length === 1 ? event.key.toLowerCase() : event.key;
+
+      if (key === expected) {
+        progress += 1;
+        if (progress === KONAMI_SEQUENCE.length) {
+          progress = 0;
+          if (shouldReduceMotion) {
+            setToast("30 lives added. (confetti skipped — reduced motion)");
+          } else {
+            fireConfetti();
+            setToast("Konami code accepted. Enjoy the confetti.");
+          }
+        }
+      } else {
+        progress = key === KONAMI_SEQUENCE[0] ? 1 : 0;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [shouldReduceMotion]);
+
+  useEffect(() => {
+    if (!toast) return undefined;
+
+    const timeout = window.setTimeout(() => setToast(null), 4000);
+    return () => window.clearTimeout(timeout);
+  }, [toast]);
+
+  useEffect(() => {
+    const originalTitle = document.title;
+
+    const handleVisibilityChange = () => {
+      document.title = document.hidden ? AWAY_TITLE : originalTitle;
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      document.title = originalTitle;
+    };
+  }, []);
+
+  return (
+    <AnimatePresence>
+      {toast && (
+        <motion.div
+          role="status"
+          initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: 16 }}
+          transition={{ duration: 0.4, ease: EASE_OUT_EXPO }}
+          className="fixed bottom-6 left-1/2 z-[100] -translate-x-1/2 rounded-md border border-border bg-surface px-4 py-2 font-mono text-sm text-fg shadow-lg"
+        >
+          <span className="mr-2 text-accent">❯</span>
+          {toast}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from "react";
+import Lenis from "lenis";
+
+/**
+ * Mounts a Lenis smooth-scroll instance on the document for the lifetime of
+ * the component. Renders nothing. Fully skipped (Lenis is never instantiated)
+ * when the user prefers reduced motion, and torn down again if the
+ * preference changes mid-session.
+ */
+export const SmoothScroll = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") return undefined;
+
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+
+    let lenis: Lenis | undefined;
+    let rafId: number | undefined;
+
+    const start = () => {
+      lenis = new Lenis({ anchors: true });
+
+      const raf = (time: number) => {
+        lenis?.raf(time);
+        rafId = requestAnimationFrame(raf);
+      };
+      rafId = requestAnimationFrame(raf);
+    };
+
+    const stop = () => {
+      if (rafId !== undefined) cancelAnimationFrame(rafId);
+      lenis?.destroy();
+      lenis = undefined;
+      rafId = undefined;
+    };
+
+    if (!mediaQuery.matches) {
+      start();
+    }
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        stop();
+      } else {
+        start();
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleChange);
+      stop();
+    };
+  }, []);
+
+  return null;
+};

--- a/src/components/SmoothScroll.tsx
+++ b/src/components/SmoothScroll.tsx
@@ -1,6 +1,12 @@
 import { useEffect } from "react";
 import Lenis from "lenis";
 
+// Tracks the currently-mounted Lenis instance (if any) so that JS-driven
+// navigation elsewhere in the app (Header links, command palette) can hand
+// scrolling off to Lenis instead of fighting it with native scrollIntoView.
+// See scrollToSection below.
+let lenisInstance: Lenis | null = null;
+
 /**
  * Mounts a Lenis smooth-scroll instance on the document for the lifetime of
  * the component. Renders nothing. Fully skipped (Lenis is never instantiated)
@@ -18,6 +24,7 @@ export const SmoothScroll = () => {
 
     const start = () => {
       lenis = new Lenis({ anchors: true });
+      lenisInstance = lenis;
 
       const raf = (time: number) => {
         lenis?.raf(time);
@@ -31,6 +38,7 @@ export const SmoothScroll = () => {
       lenis?.destroy();
       lenis = undefined;
       rafId = undefined;
+      lenisInstance = null;
     };
 
     if (!mediaQuery.matches) {
@@ -54,4 +62,27 @@ export const SmoothScroll = () => {
   }, []);
 
   return null;
+};
+
+/**
+ * Navigates to a section by id, preferring the live Lenis instance (so the
+ * scroll stays virtualized/animated consistently with user-driven scrolling)
+ * and falling back to native scrollIntoView when Lenis isn't mounted (e.g.
+ * reduced-motion preference). Safe to call from anywhere; no-ops if the
+ * target element doesn't exist.
+ */
+export const scrollToSection = (id: string): void => {
+  if (typeof document === "undefined") return;
+
+  const el = document.getElementById(id);
+  if (!el) return;
+
+  if (lenisInstance) {
+    lenisInstance.scrollTo(el);
+    return;
+  }
+
+  const prefersReduced =
+    typeof window !== "undefined" && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  el.scrollIntoView({ behavior: prefersReduced ? "auto" : "smooth" });
 };

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,18 +1,31 @@
-import { Button } from "@material-tailwind/react";
+import { useEffect, useState } from "react";
 import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 export const ThemeSwitcher = () => {
   const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  if (!mounted) {
+    return (
+      <button type="button" className="rounded-md p-2 text-fg-muted" aria-label="Color mode switch" disabled>
+        <Sun className="size-5" />
+      </button>
+    );
+  }
 
   return (
-    <Button
-      variant="text"
-      className="duration-200 hover:scale-110 active:scale-100 text-white-500 dark:text-gray-200"
+    <button
+      type="button"
       onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+      className="rounded-md p-2 text-fg-muted transition-transform duration-200 hover:scale-110 hover:text-fg active:scale-100"
       aria-label="Color mode switch"
     >
       {theme === "light" ? <Moon className="size-5" /> : <Sun className="size-5" />}
-    </Button>
+    </button>
   );
 };

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -8,7 +8,7 @@ export const Footer: FC = () => {
     <footer className="border-t border-border">
       <div className="container mx-auto flex items-center justify-between p-4 sm:flex-row sm:p-6">
         <Link href="/">
-          <Image src="/logo-white.svg" alt="logo-marco" height={60} width={60} className="invert dark:invert-0" />
+          <Image src="/logo-white.svg" alt="logo-marco" height={60} width={60} className="h-[60px] w-[60px] invert dark:invert-0" />
         </Link>
 
         <div className="-mx-2 flex">

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -5,17 +5,17 @@ import Link from "next/link";
 
 export const Footer: FC = () => {
   return (
-    <footer className={`bg-transparent`}>
+    <footer className="border-t border-border">
       <div className="container mx-auto flex items-center justify-between p-4 sm:flex-row sm:p-6">
         <Link href="/">
-          <Image src="/logo-white.svg" alt="logo-marco" height={60} width={60} className="text-black" />
+          <Image src="/logo-white.svg" alt="logo-marco" height={60} width={60} className="invert dark:invert-0" />
         </Link>
 
         <div className="-mx-2 flex">
           <Link
             href="https://www.linkedin.com/in/marco-escaleira00/"
             target="_blank"
-            className="mx-2 text-gray-200 transition-colors duration-300 hover:text-blue-500 dark:text-gray-300 dark:hover:text-blue-400"
+            className="mx-2 text-fg-muted transition-colors duration-300 hover:text-accent"
             aria-label="LinkedIn"
           >
             <Linkedin />
@@ -24,13 +24,15 @@ export const Footer: FC = () => {
           <Link
             href="https://github.com/MarcoEscaleira"
             target="_blank"
-            className="mx-2 text-gray-200 transition-colors duration-300 hover:text-blue-500 dark:text-gray-300 dark:hover:text-blue-400"
+            className="mx-2 text-fg-muted transition-colors duration-300 hover:text-accent"
             aria-label="Github"
           >
             <Github />
           </Link>
         </div>
       </div>
+
+      <p className="pb-4 text-center font-mono text-xs text-fg-muted sm:pb-6">Built with Next.js</p>
     </footer>
   );
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,28 +1,38 @@
 import { FC } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import { ThemeSwitcher } from "src/components/ThemeSwitcher";
+import { ThemeSwitcher } from "@/components/ThemeSwitcher";
+
+const NAV_LINKS: [string, string][] = [
+  ["Home", "home"],
+  ["Projects", "projects"],
+  ["Experience", "experience"],
+  ["Contact", "contact"],
+];
 
 export const Header: FC = () => {
   return (
-    <header className="flex w-full">
+    <header className="flex w-full border-b border-border">
       <div className="container mx-auto flex items-center justify-between py-2 pl-4 sm:flex-row sm:p-6">
         <section className="flex items-center">
-          <Image src="/logo-white.svg" alt="logo-marco" height={60} width={60} loading="lazy" />
+          <Image
+            src="/logo-white.svg"
+            alt="logo-marco"
+            height={60}
+            width={60}
+            loading="lazy"
+            className="invert dark:invert-0"
+          />
           <nav className="ml-8 flex gap-4 md:ml-12">
-            {[
-              ["Home", "landing"],
-              ["Contact", "contact"],
-            ].map(([title, path]) => {
+            {NAV_LINKS.map(([title, id]) => {
               return (
                 <Link
-                  key={path}
-                  href={`#${path}`}
-                  className="hover:text-slate-200 px-3 py-2 font-medium hover:border-b hover:border-b-white"
+                  key={id}
+                  href={`#${id}`}
+                  className="px-3 py-2 font-medium text-fg hover:border-b hover:border-b-accent"
                   onClick={e => {
                     e.preventDefault();
-                    // @ts-ignore
-                    window?.document?.getElementById(path).scrollIntoView({ behavior: "smooth" });
+                    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
                   }}
                 >
                   {title}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { scrollToSection } from "@/components/SmoothScroll";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 
 const NAV_LINKS: [string, string][] = [
@@ -32,7 +33,7 @@ export const Header: FC = () => {
                   className="px-3 py-2 font-medium text-fg hover:border-b hover:border-b-accent"
                   onClick={e => {
                     e.preventDefault();
-                    document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+                    scrollToSection(id);
                   }}
                 >
                   {title}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,18 +22,22 @@ export const Header: FC = () => {
             height={60}
             width={60}
             loading="lazy"
-            className="invert dark:invert-0"
+            className="h-[60px] w-[60px] invert dark:invert-0"
           />
           <nav className="ml-8 flex gap-4 md:ml-12">
             {NAV_LINKS.map(([title, id]) => {
               return (
                 <Link
                   key={id}
-                  href={`#${id}`}
+                  href={`/#${id}`}
                   className="px-3 py-2 font-medium text-fg hover:border-b hover:border-b-accent"
                   onClick={e => {
-                    e.preventDefault();
-                    scrollToSection(id);
+                    // Off the home page (e.g. 404) the section doesn't exist —
+                    // let Link navigate to /#id instead of smooth-scrolling.
+                    if (document.getElementById(id)) {
+                      e.preventDefault();
+                      scrollToSection(id);
+                    }
                   }}
                 >
                   {title}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,15 +22,15 @@ export const Header: FC = () => {
             height={60}
             width={60}
             loading="lazy"
-            className="h-[60px] w-[60px] invert dark:invert-0"
+            className="h-10 w-10 invert dark:invert-0 sm:h-[60px] sm:w-[60px]"
           />
-          <nav className="ml-8 flex gap-4 md:ml-12">
+          <nav className="ml-2 flex sm:ml-8 sm:gap-4 md:ml-12">
             {NAV_LINKS.map(([title, id]) => {
               return (
                 <Link
                   key={id}
                   href={`/#${id}`}
-                  className="px-3 py-2 font-medium text-fg hover:border-b hover:border-b-accent"
+                  className="px-1.5 py-2 text-sm font-medium text-fg hover:border-b hover:border-b-accent sm:px-3 sm:text-base"
                   onClick={e => {
                     // Off the home page (e.g. 404) the section doesn't exist —
                     // let Link navigate to /#id instead of smooth-scrolling.

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,11 +1,13 @@
 import { PropsWithChildren } from "react";
 import { Analytics } from "@vercel/analytics/react";
-import { Inter } from "next/font/google";
+import { Inter, JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import Head from "next/head";
 import { ThemeProvider } from "next-themes";
 import { Header, Footer } from "@/components/layout";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-space-grotesk" });
+const jetbrainsMono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-jetbrains-mono" });
 
 export const Layout = ({ children }: PropsWithChildren) => {
   return (
@@ -19,10 +21,12 @@ export const Layout = ({ children }: PropsWithChildren) => {
       </Head>
 
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        <div className="flex h-full min-h-screen w-full flex-col scroll-smooth bg-gradient-to-r from-blue-600 via-blue-800 to-blue-900 text-gray-100 dark:from-gray-700 dark:via-gray-800 dark:to-gray-900 dark:text-white">
+        <div
+          className={`${inter.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} flex h-full min-h-screen w-full flex-col bg-bg text-fg`}
+        >
           <Header />
 
-          <main className={`${inter.className} flex flex-1 justify-center`}>{children}</main>
+          <main className="flex flex-1 justify-center font-sans">{children}</main>
 
           <Footer />
         </div>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,15 +1,52 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useEffect, useState } from "react";
 import { Analytics } from "@vercel/analytics/react";
 import { Inter, JetBrains_Mono, Space_Grotesk } from "next/font/google";
 import Head from "next/head";
 import { ThemeProvider } from "next-themes";
+import { CommandPalette } from "@/components/CommandPalette";
+import { EasterEggs } from "@/components/EasterEggs";
 import { Header, Footer } from "@/components/layout";
+import { SmoothScroll } from "@/components/SmoothScroll";
 
 const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
 const spaceGrotesk = Space_Grotesk({ subsets: ["latin"], variable: "--font-space-grotesk" });
 const jetbrainsMono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-jetbrains-mono" });
 
+const FONT_VARIABLES = `${inter.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable}`;
+
 export const Layout = ({ children }: PropsWithChildren) => {
+  const [paletteOpen, setPaletteOpen] = useState(false);
+
+  useEffect(() => {
+    // Radix (used by cmdk's Command.Dialog) portals into document.body,
+    // outside the font-variable scope below, so font-mono/font-sans/font-display
+    // would silently fail inside the palette without this.
+    const classes = FONT_VARIABLES.split(" ").filter(Boolean);
+    document.body.classList.add(...classes);
+    return () => {
+      document.body.classList.remove(...classes);
+    };
+  }, []);
+
+  useEffect(() => {
+    const openPalette = () => setPaletteOpen(true);
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key.toLowerCase() === "k" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        setPaletteOpen(current => !current);
+      }
+    };
+
+    window.addEventListener("open-command-palette", openPalette);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      window.removeEventListener("open-command-palette", openPalette);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, []);
+
   return (
     <>
       <Head>
@@ -21,15 +58,17 @@ export const Layout = ({ children }: PropsWithChildren) => {
       </Head>
 
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        <div
-          className={`${inter.variable} ${spaceGrotesk.variable} ${jetbrainsMono.variable} flex h-full min-h-screen w-full flex-col bg-bg text-fg`}
-        >
+        <div className={`${FONT_VARIABLES} flex h-full min-h-screen w-full flex-col bg-bg text-fg`}>
           <Header />
 
           <main className="flex flex-1 justify-center font-sans">{children}</main>
 
           <Footer />
         </div>
+
+        <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} />
+        <EasterEggs />
+        <SmoothScroll />
       </ThemeProvider>
 
       <Analytics />

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -1,0 +1,82 @@
+import { motion, useReducedMotion } from "motion/react";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const FUN_FACTS = [
+  "Started out writing PHP + jQuery, and I'm not ashamed of it.",
+  "Taught humans before teaching computers was even a job title.",
+  "On-call survivor: the pager and I have an understanding.",
+  "Went from a Faculty of Medicine to Tap to Pay — long story.",
+];
+
+export const About = () => {
+  const shouldReduceMotion = useReducedMotion();
+
+  const reveal = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: EASE_OUT_EXPO } },
+  };
+
+  return (
+    <section id="about" className="w-full py-20 sm:py-28">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={reveal}
+          className="mb-10 flex items-baseline gap-3"
+        >
+          <span className="font-mono text-sm text-accent">01.</span>
+          <h2 className="font-display text-3xl font-semibold sm:text-4xl">About</h2>
+        </motion.div>
+
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-[1.4fr_1fr]">
+          <motion.div
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.3 }}
+            variants={reveal}
+            className="space-y-4 text-fg-muted"
+          >
+            <p>
+              I grew up in Portugal and studied Computer Science, graduating with a First-class degree. I took my first
+              steps as a developer at the Faculty of Medicine in Porto, then taught at Mindera Academy before making the
+              move from Porto to London.
+            </p>
+            <p>
+              These days I build payment products at yetipay — most recently Tap to Pay on iPhone and Android — and I
+              carry the on-call pager for a live payments platform, which is its own kind of education.
+            </p>
+            <p className="rounded-md border border-border bg-surface px-4 py-3 font-mono text-sm text-fg">
+              <span className="text-accent">Currently:</span> building the yetipay merchant app in React Native, with
+              Tap to Pay on both iOS and Android.
+            </p>
+          </motion.div>
+
+          <motion.ul
+            initial="hidden"
+            whileInView="show"
+            viewport={{ once: true, amount: 0.3 }}
+            variants={{
+              hidden: {},
+              show: { transition: { staggerChildren: shouldReduceMotion ? 0 : 0.1 } },
+            }}
+            className="space-y-3"
+          >
+            {FUN_FACTS.map((fact, i) => (
+              <motion.li
+                key={fact}
+                variants={reveal}
+                className="rounded-md border border-border bg-surface px-4 py-3 text-sm text-fg-muted"
+                style={{ transform: i % 2 === 0 ? "rotate(-0.6deg)" : "rotate(0.6deg)" }}
+              >
+                {fact}
+              </motion.li>
+            ))}
+          </motion.ul>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -1,0 +1,77 @@
+import { Download, Github, Linkedin, Mail } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import Link from "next/link";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const EMAIL = "marcoescaleira2000@gmail.com";
+
+const SECONDARY_LINKS = [
+  { href: "https://www.linkedin.com/in/marco-escaleira00/", label: "LinkedIn", icon: Linkedin },
+  { href: "https://github.com/MarcoEscaleira", label: "GitHub", icon: Github },
+  { href: "/Marco-Escaleira-CV.pdf", label: "Download CV", icon: Download, download: true },
+];
+
+export const Contact = () => {
+  const shouldReduceMotion = useReducedMotion();
+
+  const reveal = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: EASE_OUT_EXPO } },
+  };
+
+  return (
+    <section id="contact" className="w-full py-20 sm:py-28">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={reveal}
+          className="mb-10 flex items-baseline gap-3"
+        >
+          <span className="font-mono text-sm text-accent">03.</span>
+          <h2 className="font-display text-3xl font-semibold sm:text-4xl">Contact</h2>
+        </motion.div>
+
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={reveal}
+          className="rounded-lg border border-border bg-surface px-6 py-10 sm:px-10"
+        >
+          <p className="max-w-lg text-fg-muted">
+            Got a role, a project, or just want to talk shop about payments and React Native? My inbox is open.
+          </p>
+
+          <Link
+            href={`mailto:${EMAIL}`}
+            className="mt-6 inline-flex items-center gap-3 rounded-md bg-accent px-6 py-3 font-display text-lg font-semibold text-accent-fg transition-opacity hover:opacity-90"
+          >
+            <Mail className="size-5" />
+            Say hello
+          </Link>
+
+          <p className="mt-3 font-mono text-sm text-fg-muted">{EMAIL}</p>
+
+          <div className="mt-8 flex flex-wrap items-center gap-4 border-t border-border pt-6">
+            {SECONDARY_LINKS.map(({ href, label, icon: Icon, download }) => (
+              <Link
+                key={label}
+                href={href}
+                target={download ? undefined : "_blank"}
+                rel={download ? undefined : "noreferrer"}
+                download={download}
+                className="flex items-center gap-2 text-sm text-fg-muted transition-colors hover:text-accent"
+              >
+                <Icon className="size-4" />
+                {label}
+              </Link>
+            ))}
+          </div>
+        </motion.div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -30,7 +30,7 @@ export const Contact = () => {
           variants={reveal}
           className="mb-10 flex items-baseline gap-3"
         >
-          <span className="font-mono text-sm text-accent">03.</span>
+          <span className="font-mono text-sm text-accent">05.</span>
           <h2 className="font-display text-3xl font-semibold sm:text-4xl">Contact</h2>
         </motion.div>
 

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -1,0 +1,98 @@
+import { motion, useReducedMotion } from "motion/react";
+import Link from "next/link";
+import { experience } from "@/data/experience";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+export const Experience = () => {
+  const shouldReduceMotion = useReducedMotion();
+
+  const reveal = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: EASE_OUT_EXPO } },
+  };
+
+  const entry = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, x: -16 },
+    show: { opacity: 1, x: 0, transition: { duration: 0.5, ease: EASE_OUT_EXPO } },
+  };
+
+  return (
+    <section id="experience" className="w-full py-20 sm:py-28">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={reveal}
+          className="mb-10 flex items-baseline gap-3"
+        >
+          <span className="font-mono text-sm text-accent">03.</span>
+          <h2 className="font-display text-3xl font-semibold sm:text-4xl">Experience</h2>
+        </motion.div>
+
+        <ol className="relative space-y-10 border-l border-border pl-8 sm:pl-10">
+          {experience.map(({ company, role, location, period, highlights, url }) => (
+            <motion.li
+              key={company}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true, amount: 0.3 }}
+              variants={entry}
+              className="relative"
+            >
+              <span
+                aria-hidden
+                className="absolute -left-[2.35rem] top-1.5 size-3 rounded-full border-2 border-accent bg-bg sm:-left-[2.85rem]"
+              />
+
+              <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1">
+                <h3 className="font-display text-lg font-semibold sm:text-xl">
+                  {url ? (
+                    <Link
+                      href={url}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="underline decoration-border decoration-2 underline-offset-4 transition-colors hover:decoration-accent"
+                    >
+                      {company}
+                    </Link>
+                  ) : (
+                    company
+                  )}
+                </h3>
+                {period && (
+                  <span
+                    className={
+                      period === "Current"
+                        ? "rounded-full bg-accent px-2.5 py-0.5 font-mono text-xs font-medium text-accent-fg"
+                        : "font-mono text-xs text-fg-muted"
+                    }
+                  >
+                    {period}
+                  </span>
+                )}
+              </div>
+
+              <p className="mt-0.5 text-sm text-fg-muted">
+                {role}
+                {location && <span className="text-fg-muted/70"> · {location}</span>}
+              </p>
+
+              {highlights.length > 0 && (
+                <ul className="mt-3 space-y-1.5">
+                  {highlights.map(highlight => (
+                    <li key={highlight} className="flex gap-2 text-sm text-fg-muted">
+                      <span aria-hidden className="mt-2 size-1 flex-none rounded-full bg-fg-muted" />
+                      {highlight}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </motion.li>
+          ))}
+        </ol>
+      </div>
+    </section>
+  );
+};

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -35,8 +35,14 @@ const RoleCycle = () => {
     if (shouldReduceMotion) return;
 
     const interval = setInterval(() => {
-      setIndex(current => (current + 1) % ROLE_WORDS.length);
-    }, 2200);
+      setIndex(current => {
+        const next = current + 1;
+        if (next >= ROLE_WORDS.length - 1) {
+          clearInterval(interval);
+        }
+        return Math.min(next, ROLE_WORDS.length - 1);
+      });
+    }, 1200);
 
     return () => clearInterval(interval);
   }, [shouldReduceMotion]);
@@ -128,6 +134,7 @@ export const Hero = () => {
             <button
               type="button"
               onClick={openCommandPalette}
+              aria-label="Open command palette"
               className="group flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 font-mono text-xs text-fg-muted transition-colors hover:border-accent hover:text-fg"
             >
               <span className="rounded border border-border bg-bg px-1.5 py-0.5 text-fg group-hover:border-accent">

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Github, Linkedin } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import Image from "next/image";
@@ -7,6 +7,8 @@ import Link from "next/link";
 const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
 
 const ROLE_WORDS = ["React Native", "payments", "design systems", "Node & AWS"];
+
+const LONGEST_ROLE_WORD = ROLE_WORDS.reduce((longest, word) => (word.length > longest.length ? word : longest));
 
 const SOCIAL_LINKS = [
   { href: "https://github.com/MarcoEscaleira", label: "GitHub", icon: Github },
@@ -30,18 +32,19 @@ const useIsMac = () => {
 const RoleCycle = () => {
   const shouldReduceMotion = useReducedMotion();
   const [index, setIndex] = useState(0);
+  const indexRef = useRef(0);
 
   useEffect(() => {
     if (shouldReduceMotion) return;
 
     const interval = setInterval(() => {
-      setIndex(current => {
-        const next = current + 1;
-        if (next >= ROLE_WORDS.length - 1) {
-          clearInterval(interval);
-        }
-        return Math.min(next, ROLE_WORDS.length - 1);
-      });
+      const next = indexRef.current + 1;
+      indexRef.current = Math.min(next, ROLE_WORDS.length - 1);
+      setIndex(indexRef.current);
+
+      if (next >= ROLE_WORDS.length - 1) {
+        clearInterval(interval);
+      }
     }, 1200);
 
     return () => clearInterval(interval);
@@ -52,7 +55,10 @@ const RoleCycle = () => {
   }
 
   return (
-    <span className="relative inline-block h-[1.2em] min-w-[9ch] align-bottom">
+    <span className="relative inline-block h-[1.2em] align-bottom">
+      <span className="invisible" aria-hidden="true">
+        {LONGEST_ROLE_WORD}
+      </span>
       <AnimatePresence mode="wait">
         <motion.span
           key={ROLE_WORDS[index]}

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -182,7 +182,7 @@ export const Hero = () => {
               width={220}
               height={220}
               priority
-              className="relative rounded-full border-4 border-surface object-cover shadow-lg shadow-accent/10"
+              className="relative h-[220px] w-[220px] rounded-full border-4 border-surface object-cover shadow-lg shadow-accent/10"
             />
           </div>
         </motion.div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useState } from "react";
+import { Github, Linkedin } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import Image from "next/image";
+import Link from "next/link";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const ROLE_WORDS = ["React Native", "payments", "design systems", "Node & AWS"];
+
+const SOCIAL_LINKS = [
+  { href: "https://github.com/MarcoEscaleira", label: "GitHub", icon: Github },
+  { href: "https://www.linkedin.com/in/marco-escaleira00/", label: "LinkedIn", icon: Linkedin },
+];
+
+const openCommandPalette = () => {
+  window.dispatchEvent(new CustomEvent("open-command-palette"));
+};
+
+const useIsMac = () => {
+  const [isMac, setIsMac] = useState(true);
+
+  useEffect(() => {
+    setIsMac(typeof navigator !== "undefined" && /mac/i.test(navigator.platform));
+  }, []);
+
+  return isMac;
+};
+
+const RoleCycle = () => {
+  const shouldReduceMotion = useReducedMotion();
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (shouldReduceMotion) return;
+
+    const interval = setInterval(() => {
+      setIndex(current => (current + 1) % ROLE_WORDS.length);
+    }, 2200);
+
+    return () => clearInterval(interval);
+  }, [shouldReduceMotion]);
+
+  if (shouldReduceMotion) {
+    return <span className="text-accent">{ROLE_WORDS[0]}</span>;
+  }
+
+  return (
+    <span className="relative inline-block h-[1.2em] min-w-[9ch] align-bottom">
+      <AnimatePresence mode="wait">
+        <motion.span
+          key={ROLE_WORDS[index]}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -10 }}
+          transition={{ duration: 0.35, ease: EASE_OUT_EXPO }}
+          className="absolute left-0 top-0 whitespace-nowrap text-accent"
+        >
+          {ROLE_WORDS[index]}
+        </motion.span>
+      </AnimatePresence>
+    </span>
+  );
+};
+
+export const Hero = () => {
+  const shouldReduceMotion = useReducedMotion();
+  const isMac = useIsMac();
+
+  const container = {
+    hidden: {},
+    show: {
+      transition: { staggerChildren: shouldReduceMotion ? 0 : 0.12 },
+    },
+  };
+
+  const item = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 24 },
+    show: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.6, ease: EASE_OUT_EXPO },
+    },
+  };
+
+  return (
+    <section id="home" className="relative w-full overflow-hidden py-20 sm:py-28">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-24 -top-24 h-72 w-72 rounded-full bg-accent/10 blur-3xl"
+      />
+      <motion.div
+        variants={container}
+        initial="hidden"
+        animate="show"
+        className="mx-auto grid w-full max-w-5xl grid-cols-1 items-center gap-12 px-6 md:grid-cols-[1.2fr_0.8fr] md:gap-8"
+      >
+        <div className="order-2 md:order-1">
+          <motion.p variants={item} className="mb-4 font-mono text-sm text-fg-muted">
+            hello world, I&apos;m
+          </motion.p>
+
+          <motion.h1
+            variants={item}
+            className="text-balance font-display text-4xl font-semibold leading-[1.05] sm:text-5xl lg:text-6xl"
+          >
+            Marco Escaleira
+          </motion.h1>
+
+          <motion.p variants={item} className="mt-4 text-lg text-fg-muted sm:text-xl">
+            Full-stack engineer — React, React Native, Node, AWS
+          </motion.p>
+
+          <motion.p variants={item} className="mt-2 text-base text-fg-muted">
+            Building <RoleCycle /> at{" "}
+            <Link
+              href="https://yetipay.me"
+              target="_blank"
+              rel="noreferrer"
+              className="font-medium text-fg underline decoration-border decoration-2 underline-offset-4 transition-colors hover:decoration-accent"
+            >
+              yetipay
+            </Link>{" "}
+            in London.
+          </motion.p>
+
+          <motion.div variants={item} className="mt-8 flex flex-wrap items-center gap-4">
+            <button
+              type="button"
+              onClick={openCommandPalette}
+              className="group flex items-center gap-2 rounded-md border border-border bg-surface px-3 py-2 font-mono text-xs text-fg-muted transition-colors hover:border-accent hover:text-fg"
+            >
+              <span className="rounded border border-border bg-bg px-1.5 py-0.5 text-fg group-hover:border-accent">
+                {isMac ? "⌘" : "Ctrl"}
+              </span>
+              <span className="rounded border border-border bg-bg px-1.5 py-0.5 text-fg group-hover:border-accent">
+                K
+              </span>
+              <span>to explore</span>
+            </button>
+
+            <div className="flex items-center gap-1">
+              {SOCIAL_LINKS.map(({ href, label, icon: Icon }) => (
+                <Link
+                  key={label}
+                  href={href}
+                  target="_blank"
+                  rel="noreferrer"
+                  aria-label={label}
+                  className="rounded-md p-2 text-fg-muted transition-colors duration-200 hover:text-accent"
+                >
+                  <Icon className="size-5" />
+                </Link>
+              ))}
+            </div>
+          </motion.div>
+        </div>
+
+        <motion.div variants={item} className="order-1 flex justify-center md:order-2 md:justify-end">
+          <div className="relative">
+            <div
+              aria-hidden
+              className="absolute -inset-3 rounded-full border border-accent/40"
+              style={{ borderStyle: "dashed" }}
+            />
+            <Image
+              src="/marco.jpg"
+              alt="Portrait of Marco Escaleira"
+              width={220}
+              height={220}
+              priority
+              className="relative rounded-full border-4 border-surface object-cover shadow-lg shadow-accent/10"
+            />
+          </div>
+        </motion.div>
+      </motion.div>
+    </section>
+  );
+};

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -40,7 +40,7 @@ const ProjectCard = ({ project, isOpen, onToggle }: ProjectCardProps) => {
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
-        aria-controls={panelId}
+        aria-controls={isOpen ? panelId : undefined}
         className="group flex w-full items-start justify-between gap-4 px-5 py-5 text-left sm:px-6 sm:py-6"
       >
         <div className="min-w-0">

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,0 +1,190 @@
+import { useId, useState } from "react";
+import { ChevronDown, ExternalLink, Github, Globe, Server, Smartphone, Sparkles } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import Link from "next/link";
+import { projects, type Project } from "@/data/projects";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const LINK_META: Record<
+  keyof Project["links"],
+  { label: string; icon: typeof ExternalLink }
+> = {
+  live: { label: "Live site", icon: Globe },
+  repo: { label: "Repo", icon: Github },
+  repoBackend: { label: "Backend repo", icon: Server },
+  repoMobile: { label: "Mobile repo", icon: Smartphone },
+  company: { label: "Company", icon: ExternalLink },
+};
+
+const LINK_ORDER: Array<keyof Project["links"]> = ["live", "company", "repo", "repoBackend", "repoMobile"];
+
+interface ProjectCardProps {
+  project: Project;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+const ProjectCard = ({ project, isOpen, onToggle }: ProjectCardProps) => {
+  const shouldReduceMotion = useReducedMotion();
+  const panelId = useId();
+  const availableLinks = LINK_ORDER.filter(key => project.links[key]);
+
+  return (
+    <div
+      className={`rounded-lg border bg-surface transition-colors ${
+        project.flagship ? "border-accent/60" : "border-border"
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        className="group flex w-full items-start justify-between gap-4 px-5 py-5 text-left sm:px-6 sm:py-6"
+      >
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            {project.flagship && (
+              <span className="inline-flex items-center gap-1 rounded-full bg-accent px-2.5 py-0.5 font-mono text-xs font-medium text-accent-fg">
+                <Sparkles className="size-3" />
+                Flagship
+              </span>
+            )}
+            <h3
+              className={`font-display font-semibold ${
+                project.flagship ? "text-2xl sm:text-3xl" : "text-xl sm:text-2xl"
+              }`}
+            >
+              {project.title}
+            </h3>
+            {project.year && <span className="font-mono text-xs text-fg-muted">{project.year}</span>}
+          </div>
+          <p className="mt-1.5 text-fg-muted">{project.tagline}</p>
+          <div className="mt-4 flex flex-wrap gap-2">
+            {project.stack.map(tech => (
+              <span
+                key={tech}
+                className="rounded-full border border-border bg-bg px-2.5 py-1 font-mono text-xs text-fg-muted"
+              >
+                {tech}
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <span
+          aria-hidden
+          className="mt-1 flex size-8 flex-none items-center justify-center rounded-full border border-border text-fg-muted transition-colors group-hover:text-accent"
+        >
+          <motion.span
+            animate={{ rotate: isOpen ? 180 : 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.3, ease: EASE_OUT_EXPO }}
+            className="flex"
+          >
+            <ChevronDown className="size-4" />
+          </motion.span>
+        </span>
+      </button>
+
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            id={panelId}
+            key="content"
+            initial={shouldReduceMotion ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={shouldReduceMotion ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.35, ease: EASE_OUT_EXPO }}
+            className="overflow-hidden"
+          >
+            <div className="space-y-4 border-t border-border px-5 pb-6 pt-5 sm:px-6">
+              <div>
+                <h4 className="font-mono text-xs uppercase tracking-wide text-accent">Problem</h4>
+                <p className="mt-1.5 text-sm text-fg-muted">{project.problem}</p>
+              </div>
+              <div>
+                <h4 className="font-mono text-xs uppercase tracking-wide text-accent">What I built</h4>
+                <p className="mt-1.5 text-sm text-fg-muted">{project.built}</p>
+              </div>
+              <div>
+                <h4 className="font-mono text-xs uppercase tracking-wide text-accent">Outcome</h4>
+                <p className="mt-1.5 text-sm text-fg-muted">{project.outcome}</p>
+              </div>
+
+              {availableLinks.length > 0 && (
+                <div className="flex flex-wrap items-center gap-4 pt-1">
+                  {availableLinks.map(key => {
+                    const { label, icon: Icon } = LINK_META[key];
+                    return (
+                      <Link
+                        key={key}
+                        href={project.links[key] as string}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="flex items-center gap-1.5 text-sm font-medium text-fg transition-colors hover:text-accent"
+                      >
+                        <Icon className="size-4" />
+                        {label}
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export const Projects = () => {
+  const shouldReduceMotion = useReducedMotion();
+  const [openSlug, setOpenSlug] = useState<string | null>(projects.find(p => p.flagship)?.slug ?? null);
+
+  const reveal = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: EASE_OUT_EXPO } },
+  };
+
+  const list = {
+    hidden: {},
+    show: { transition: { staggerChildren: shouldReduceMotion ? 0 : 0.08 } },
+  };
+
+  return (
+    <section id="projects" className="w-full py-20 sm:py-28">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={reveal}
+          className="mb-10 flex items-baseline gap-3"
+        >
+          <span className="font-mono text-sm text-accent">02.</span>
+          <h2 className="font-display text-3xl font-semibold sm:text-4xl">Projects</h2>
+        </motion.div>
+
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.2 }}
+          variants={list}
+          className="space-y-4"
+        >
+          {projects.map(project => (
+            <motion.div key={project.slug} variants={reveal}>
+              <ProjectCard
+                project={project}
+                isOpen={openSlug === project.slug}
+                onToggle={() => setOpenSlug(current => (current === project.slug ? null : project.slug))}
+              />
+            </motion.div>
+          ))}
+        </motion.div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -1,0 +1,54 @@
+import { motion, useReducedMotion } from "motion/react";
+import { skills } from "@/data/skills";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+export const Skills = () => {
+  const shouldReduceMotion = useReducedMotion();
+
+  const group = {
+    hidden: {},
+    show: { transition: { staggerChildren: shouldReduceMotion ? 0 : 0.08 } },
+  };
+
+  const chip = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 12 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.4, ease: EASE_OUT_EXPO } },
+  };
+
+  return (
+    <section id="skills" className="w-full py-20 sm:py-28">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <div className="mb-10 flex items-baseline gap-3">
+          <span className="font-mono text-sm text-accent">02.</span>
+          <h2 className="font-display text-3xl font-semibold sm:text-4xl">Skills</h2>
+        </div>
+
+        <div className="space-y-8">
+          {skills.map(({ label, skills: items }) => (
+            <motion.div
+              key={label}
+              initial="hidden"
+              whileInView="show"
+              viewport={{ once: true, amount: 0.3 }}
+              variants={group}
+            >
+              <h3 className="mb-3 font-display text-sm uppercase tracking-wide text-fg-muted">{label}</h3>
+              <div className="flex flex-wrap gap-2">
+                {items.map(skill => (
+                  <motion.span
+                    key={skill}
+                    variants={chip}
+                    className="rounded-full border border-border bg-surface px-3 py-1.5 text-sm text-fg"
+                  >
+                    {skill}
+                  </motion.span>
+                ))}
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -20,7 +20,7 @@ export const Skills = () => {
     <section id="skills" className="w-full py-20 sm:py-28">
       <div className="mx-auto w-full max-w-5xl px-6">
         <div className="mb-10 flex items-baseline gap-3">
-          <span className="font-mono text-sm text-accent">02.</span>
+          <span className="font-mono text-sm text-accent">04.</span>
           <h2 className="font-display text-3xl font-semibold sm:text-4xl">Skills</h2>
         </div>
 

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -6,6 +6,11 @@ const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
 export const Skills = () => {
   const shouldReduceMotion = useReducedMotion();
 
+  const reveal = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 20 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.6, ease: EASE_OUT_EXPO } },
+  };
+
   const group = {
     hidden: {},
     show: { transition: { staggerChildren: shouldReduceMotion ? 0 : 0.08 } },
@@ -19,10 +24,16 @@ export const Skills = () => {
   return (
     <section id="skills" className="w-full py-20 sm:py-28">
       <div className="mx-auto w-full max-w-5xl px-6">
-        <div className="mb-10 flex items-baseline gap-3">
+        <motion.div
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.3 }}
+          variants={reveal}
+          className="mb-10 flex items-baseline gap-3"
+        >
           <span className="font-mono text-sm text-accent">04.</span>
           <h2 className="font-display text-3xl font-semibold sm:text-4xl">Skills</h2>
-        </div>
+        </motion.div>
 
         <div className="space-y-8">
           {skills.map(({ label, skills: items }) => (

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,0 +1,4 @@
+export { Hero } from "./Hero";
+export { About } from "./About";
+export { Skills } from "./Skills";
+export { Contact } from "./Contact";

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,4 +1,6 @@
 export { Hero } from "./Hero";
 export { About } from "./About";
+export { Projects } from "./Projects";
+export { Experience } from "./Experience";
 export { Skills } from "./Skills";
 export { Contact } from "./Contact";

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,7 +1,0 @@
-import * as React from "react";
-import { ThemeProvider as NextThemesProvider } from "next-themes";
-import type { ThemeProviderProps } from "next-themes/dist/types";
-
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
-}

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,0 +1,50 @@
+// Highlights are sourced from Marco's CV summary and are pending Marco's review.
+// TODO(marco): fill exact dates
+export interface Experience {
+  company: string;
+  role: string;
+  location?: string;
+  period: string;
+  highlights: string[];
+  url?: string;
+}
+
+export const experience: Experience[] = [
+  {
+    company: "yetipay",
+    role: "Software Engineer",
+    location: "London, UK",
+    period: "Current",
+    highlights: [
+      "Built the Tap-to-Pay merchant app for iPhone and Android with React Native",
+      "Made CI/CD pipelines ~10x faster",
+      "Design-system work across the product",
+      "On-call for a live payments platform",
+    ],
+    url: "https://yetipay.me",
+  },
+  {
+    company: "Beacon",
+    role: "Software Engineer",
+    period: "",
+    highlights: ["Improved page-load performance by ~50%"],
+  },
+  {
+    company: "Mindera",
+    role: "Software Engineer",
+    period: "",
+    highlights: ["React product work", "Defined an end-to-end testing strategy using Gherkin/Cucumber-style E2E tests"],
+  },
+  {
+    company: "Mindera Academy",
+    role: "Mentor/Teacher",
+    period: "",
+    highlights: ["Taught and mentored aspiring developers"],
+  },
+  {
+    company: "FMUP (Faculty of Medicine, University of Porto)",
+    role: "Early-career developer",
+    period: "",
+    highlights: ["First steps as a developer, doing web work for the faculty"],
+  },
+];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,80 @@
+export interface Project {
+  slug: string;
+  title: string;
+  tagline: string;
+  problem: string;
+  built: string;
+  stack: string[];
+  outcome: string;
+  links: {
+    live?: string;
+    repo?: string;
+    repoBackend?: string;
+    repoMobile?: string;
+    company?: string;
+  };
+  flagship?: boolean;
+  year?: string;
+}
+
+export const projects: Project[] = [
+  {
+    slug: "yetipay-merchant-app",
+    title: "yetipay Merchant App",
+    tagline: "Tap to Pay on your phone — no extra hardware required.",
+    problem: "Small merchants need to take card payments without buying extra hardware.",
+    built:
+      "A React Native merchant app with Tap to Pay on both iPhone and Android, plus card reader integration for merchants who want it. It's backed by an AWS payments platform underneath. I work on this full-time, from the mobile app to the infrastructure that keeps it running.",
+    stack: ["React Native", "TypeScript", "iOS/Android Tap to Pay", "AWS"],
+    outcome:
+      "A live, in-production payments platform merchants use today to take card payments straight from their phone.",
+    links: {
+      company: "https://yetipay.me",
+    },
+    flagship: true,
+  },
+  {
+    slug: "meet-the-countries",
+    title: "Meet The Countries",
+    tagline: "One product, three codebases, zero excuses.",
+    problem: "Wanted to prove I could own a full product end to end — web, API, and mobile — not just one layer of it.",
+    built:
+      "A full-stack side project spanning a TypeScript/React frontend, a Node/Express/GraphQL/MongoDB backend running in Docker, and a React Native/Expo mobile app. All three share the same product vision, with CI/CD pipelines and Gherkin-driven E2E tests keeping everything honest.",
+    stack: ["TypeScript", "React", "Node.js", "Express", "GraphQL", "MongoDB", "Docker", "React Native", "Expo"],
+    outcome:
+      "A shipped, live product across web and mobile, with automated tests and pipelines doing the boring work for me.",
+    links: {
+      live: "https://meetthecountries.com",
+      repo: "https://github.com/MarcoEscaleira/meetthecountries-frontend",
+      repoBackend: "https://github.com/MarcoEscaleira/meetthecountries-backend",
+      repoMobile: "https://github.com/MarcoEscaleira/meetthecountries-mobile",
+    },
+  },
+  {
+    slug: "motojoy",
+    title: "MotoJoy",
+    tagline: "Where I started — and I'm not embarrassed about it.",
+    problem: "Learning how a real e-commerce store actually works: storefront, cart, checkout, backoffice, all of it.",
+    built:
+      "A PHP, jQuery, and Bootstrap e-commerce site with a storefront, shopping cart, backoffice for managing it all, and PayPal integration for actual payments. It's not fancy by today's standards, and that's exactly the point.",
+    stack: ["PHP", "jQuery", "Bootstrap", "PayPal"],
+    outcome: "My first real end-to-end build — the project that taught me most of what came after.",
+    links: {
+      repo: "https://github.com/MarcoEscaleira/motojoy",
+    },
+  },
+  {
+    slug: "should-you-do-it",
+    title: "shouldYouDoIt",
+    tagline: "Can't decide? Let the app decide for you.",
+    problem: "Sometimes you just need something to make the call for you.",
+    built:
+      "A tiny, playful TypeScript app that makes decisions so you don't have to. No accounts, no config, just an answer.",
+    stack: ["TypeScript"],
+    outcome: "A small, fun, live tool that does exactly one thing and does it with a smile.",
+    links: {
+      repo: "https://github.com/MarcoEscaleira/shouldyoudoit",
+      live: "https://shouldyoudoit.surge.sh/",
+    },
+  },
+];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -24,7 +24,7 @@ export const projects: Project[] = [
     tagline: "Tap to Pay on your phone — no extra hardware required.",
     problem: "Small merchants need to take card payments without buying extra hardware.",
     built:
-      "A React Native merchant app with Tap to Pay on both iPhone and Android, plus card reader integration for merchants who want it. It's backed by an AWS payments platform underneath. I work on this full-time, from the mobile app to the infrastructure that keeps it running.",
+      "A React Native merchant app with Tap to Pay on both iPhone and Android, plus card reader integration for merchants who want it. It's backed by an AWS payments platform underneath. This is my day job at yetipay, and it's live in merchants' hands.",
     stack: ["React Native", "TypeScript", "iOS/Android Tap to Pay", "AWS"],
     outcome:
       "A live, in-production payments platform merchants use today to take card payments straight from their phone.",

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -1,0 +1,31 @@
+export interface SkillGroup {
+  label: string;
+  skills: string[];
+}
+
+export const skills: SkillGroup[] = [
+  {
+    label: "Languages",
+    skills: ["TypeScript", "JavaScript", "HTML", "CSS", "PHP"],
+  },
+  {
+    label: "Frontend",
+    skills: ["React", "Next.js", "Tailwind CSS", "GraphQL (Apollo)"],
+  },
+  {
+    label: "Mobile",
+    skills: ["React Native", "Expo", "Tap to Pay (iOS & Android)"],
+  },
+  {
+    label: "Backend",
+    skills: ["Node.js", "Express", "MongoDB", "REST & GraphQL APIs"],
+  },
+  {
+    label: "AWS & Infra",
+    skills: ["AWS", "Docker", "CI/CD (GitHub Actions)", "Vercel"],
+  },
+  {
+    label: "Tooling & Testing",
+    skills: ["Jest", "E2E testing (Gherkin/Cucumber)", "Git", "Storybook-style design systems"],
+  },
+];

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -1,0 +1,85 @@
+import { motion, useReducedMotion } from "motion/react";
+import Head from "next/head";
+import Link from "next/link";
+
+const EASE_OUT_EXPO: [number, number, number, number] = [0.16, 1, 0.3, 1];
+
+const openCommandPalette = () => {
+  window.dispatchEvent(new CustomEvent("open-command-palette"));
+};
+
+export default function NotFound() {
+  const shouldReduceMotion = useReducedMotion();
+
+  const reveal = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 16 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.5, ease: EASE_OUT_EXPO } },
+  };
+
+  const container = {
+    hidden: {},
+    show: { transition: { staggerChildren: shouldReduceMotion ? 0 : 0.12 } },
+  };
+
+  return (
+    <>
+      <Head>
+        <title>404 — Marco Escaleira</title>
+      </Head>
+
+      <div className="flex w-full flex-1 items-center justify-center px-6 py-24">
+        <motion.div
+          variants={container}
+          initial="hidden"
+          animate="show"
+          className="w-full max-w-lg rounded-lg border border-border bg-surface font-mono shadow-lg"
+        >
+          <div className="flex items-center gap-2 border-b border-border px-4 py-2">
+            <span className="size-2.5 rounded-full bg-border" />
+            <span className="size-2.5 rounded-full bg-border" />
+            <span className="size-2.5 rounded-full bg-border" />
+            <span className="ml-2 text-xs text-fg-muted">marco@portfolio: ~</span>
+          </div>
+
+          <div className="space-y-3 px-5 py-6 text-sm">
+            <motion.p variants={reveal} className="text-fg-muted">
+              <span className="text-accent">❯</span> cd /this-page
+            </motion.p>
+            <motion.p variants={reveal} className="text-fg">
+              cd: no such file or directory: /this-page
+            </motion.p>
+            <motion.p variants={reveal} className="pt-2 text-fg-muted">
+              <span className="text-accent">❯</span> ls -la
+            </motion.p>
+            <motion.p variants={reveal} className="text-fg">
+              404 — page not found
+            </motion.p>
+
+            <motion.div variants={reveal} className="flex flex-wrap items-center gap-4 pt-4">
+              <Link
+                href="/"
+                className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-fg transition-opacity hover:opacity-90"
+              >
+                cd ~
+              </Link>
+
+              <button
+                type="button"
+                onClick={openCommandPalette}
+                className="group flex items-center gap-2 rounded-md border border-border bg-bg px-3 py-2 text-xs text-fg-muted transition-colors hover:border-accent hover:text-fg"
+              >
+                <span className="rounded border border-border bg-surface px-1.5 py-0.5 text-fg group-hover:border-accent">
+                  ⌘
+                </span>
+                <span className="rounded border border-border bg-surface px-1.5 py-0.5 text-fg group-hover:border-accent">
+                  K
+                </span>
+                <span>try the command palette</span>
+              </button>
+            </motion.div>
+          </div>
+        </motion.div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,78 +1,13 @@
-import { Github, Linkedin } from "lucide-react";
-import Image from "next/image";
-import Link from "next/link";
+import { About, Contact, Hero, Skills } from "@/components/sections";
 
 export default function Home() {
   return (
-    <div className="container flex flex-col">
-      <section
-        id="home"
-        className="flex h-full flex-col items-center pt-8 sm:h-[calc(100vh-92px)] sm:justify-center sm:pt-0 md:flex-row"
-      >
-        <Image src="/marco.jpg" alt="Marco's face" width={200} height={200} className="rounded-[100%] shadow" />
-        <div className="p-4 md:ml-10 md:p-0">
-          <h1 className="mb-2 font-display text-3xl font-semibold sm:text-4xl lg:text-5xl">Hello there!</h1>
-          <p className="mb-6 text-lg text-fg-muted">You landed in the right place!</p>
-          <p className="mb-8 max-w-[580px] text-fg-muted">
-            I am passionate about working in an industry that I deeply appreciate and that drives me daily. With over
-            five years of experience, I am constantly motivated by the pursuit of technological and personal growth. My
-            enthusiasm for teamwork and my proactive communication style enhance our collective success.
-          </p>
-
-          <div className="hidden justify-center md:flex">
-            <Link
-              href="https://www.linkedin.com/in/marco-escaleira00/"
-              target="_blank"
-              className="mx-2 text-fg-muted transition-colors duration-300 hover:text-accent"
-              aria-label="LinkedIn"
-            >
-              <Linkedin />
-            </Link>
-
-            <Link
-              href="https://github.com/MarcoEscaleira"
-              target="_blank"
-              className="mx-2 text-fg-muted transition-colors duration-300 hover:text-accent"
-              aria-label="Github"
-            >
-              <Github />
-            </Link>
-          </div>
-        </div>
-      </section>
-
-      <section id="contact" className="h-[calc(100vh-92px)] w-full lg:flex">
-        <div className="flex w-full flex-col justify-center p-8 lg:w-1/2 lg:px-12 xl:px-32">
-          <h2 className="font-display text-2xl font-semibold capitalize lg:text-3xl">contact me.</h2>
-
-          <p className="mt-4 text-fg-muted">
-            Feel free to reach out with any questions or thoughts. I&apos;m all ears and eager to connect!
-          </p>
-
-          <div className="mt-6 flex items-center gap-1 md:mt-8">
-            <h3 className="font-medium text-fg">Follow me on</h3>
-
-            <div className="flex">
-              <Link
-                className="mx-1.5 text-fg-muted transition-colors duration-300 hover:text-accent"
-                href="https://www.linkedin.com/in/marco-escaleira00/"
-                target="_blank"
-              >
-                <Linkedin />
-              </Link>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex w-full flex-col justify-center p-8 pt-0 lg:w-1/2 lg:px-12 xl:px-24">
-          <button
-            type="button"
-            className="mt-4 w-full rounded-md bg-accent px-4 py-2 font-medium text-accent-fg transition-opacity hover:opacity-90"
-          >
-            Get in touch
-          </button>
-        </div>
-      </section>
+    <div className="flex w-full flex-col divide-y divide-border">
+      <Hero />
+      <About />
+      {/* Projects and Experience sections are inserted here by a later task */}
+      <Skills />
+      <Contact />
     </div>
   );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,3 @@
-import { Button, Typography } from "@material-tailwind/react";
 import { Github, Linkedin } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -7,28 +6,24 @@ export default function Home() {
   return (
     <div className="container flex flex-col">
       <section
-        id="landing"
+        id="home"
         className="flex h-full flex-col items-center pt-8 sm:h-[calc(100vh-92px)] sm:justify-center sm:pt-0 md:flex-row"
       >
         <Image src="/marco.jpg" alt="Marco's face" width={200} height={200} className="rounded-[100%] shadow" />
         <div className="p-4 md:ml-10 md:p-0">
-          <Typography variant="h1" className="mb-2 text-3xl sm:text-4xl lg:text-5xl">
-            Hello there!
-          </Typography>
-          <Typography variant="lead" className="mb-6">
-            You landed in the right place!
-          </Typography>
-          <Typography variant="paragraph" className="mb-8 max-w-[580px]">
+          <h1 className="mb-2 font-display text-3xl font-semibold sm:text-4xl lg:text-5xl">Hello there!</h1>
+          <p className="mb-6 text-lg text-fg-muted">You landed in the right place!</p>
+          <p className="mb-8 max-w-[580px] text-fg-muted">
             I am passionate about working in an industry that I deeply appreciate and that drives me daily. With over
             five years of experience, I am constantly motivated by the pursuit of technological and personal growth. My
             enthusiasm for teamwork and my proactive communication style enhance our collective success.
-          </Typography>
+          </p>
 
           <div className="hidden justify-center md:flex">
             <Link
               href="https://www.linkedin.com/in/marco-escaleira00/"
               target="_blank"
-              className="mx-2 text-gray-200 transition-colors duration-300 hover:text-blue-500 dark:text-gray-300 dark:hover:text-blue-400"
+              className="mx-2 text-fg-muted transition-colors duration-300 hover:text-accent"
               aria-label="LinkedIn"
             >
               <Linkedin />
@@ -37,7 +32,7 @@ export default function Home() {
             <Link
               href="https://github.com/MarcoEscaleira"
               target="_blank"
-              className="mx-2 text-gray-200 transition-colors duration-300 hover:text-blue-500 dark:text-gray-300 dark:hover:text-blue-400"
+              className="mx-2 text-fg-muted transition-colors duration-300 hover:text-accent"
               aria-label="Github"
             >
               <Github />
@@ -48,23 +43,18 @@ export default function Home() {
 
       <section id="contact" className="h-[calc(100vh-92px)] w-full lg:flex">
         <div className="flex w-full flex-col justify-center p-8 lg:w-1/2 lg:px-12 xl:px-32">
-          <Typography
-            variant="h2"
-            className="text-sky-200 text-2xl font-semibold capitalize dark:text-white lg:text-3xl"
-          >
-            contact me.
-          </Typography>
+          <h2 className="font-display text-2xl font-semibold capitalize lg:text-3xl">contact me.</h2>
 
-          <p className="text-sky-100 mt-4 dark:text-gray-400">
+          <p className="mt-4 text-fg-muted">
             Feel free to reach out with any questions or thoughts. I&apos;m all ears and eager to connect!
           </p>
 
           <div className="mt-6 flex items-center gap-1 md:mt-8">
-            <h3 className="font-medium text-gray-100 dark:text-gray-300">Follow me on</h3>
+            <h3 className="font-medium text-fg">Follow me on</h3>
 
             <div className="flex">
               <Link
-                className="mx-1.5 transform text-blue-200 transition-colors duration-300 hover:text-blue-500 dark:hover:text-blue-400"
+                className="mx-1.5 text-fg-muted transition-colors duration-300 hover:text-accent"
                 href="https://www.linkedin.com/in/marco-escaleira00/"
                 target="_blank"
               >
@@ -74,10 +64,13 @@ export default function Home() {
           </div>
         </div>
 
-        <div className="flex w-full flex-col justify-center p-8 pt-0 lg:w-1/2 lg:px-12 xl:px-24 ">
-          <Button fullWidth color="blue" className="mt-4">
+        <div className="flex w-full flex-col justify-center p-8 pt-0 lg:w-1/2 lg:px-12 xl:px-24">
+          <button
+            type="button"
+            className="mt-4 w-full rounded-md bg-accent px-4 py-2 font-medium text-accent-fg transition-opacity hover:opacity-90"
+          >
             Get in touch
-          </Button>
+          </button>
         </div>
       </section>
     </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,12 @@
-import { About, Contact, Hero, Skills } from "@/components/sections";
+import { About, Contact, Experience, Hero, Projects, Skills } from "@/components/sections";
 
 export default function Home() {
   return (
     <div className="flex w-full flex-col divide-y divide-border">
       <Hero />
       <About />
-      {/* Projects and Experience sections are inserted here by a later task */}
+      <Projects />
+      <Experience />
       <Skills />
       <Contact />
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -2,6 +2,26 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-bg: 250 249 246;
+  --color-surface: 244 242 237;
+  --color-border: 225 221 213;
+  --color-fg: 26 24 20;
+  --color-fg-muted: 90 85 78;
+  --color-accent: 4 120 87;
+  --color-accent-fg: 255 255 255;
+}
+
+.dark {
+  --color-bg: 15 15 13;
+  --color-surface: 24 24 21;
+  --color-border: 48 47 42;
+  --color-fg: 237 235 230;
+  --color-fg-muted: 163 158 148;
+  --color-accent: 52 211 153;
+  --color-accent-fg: 10 10 10;
+}
+
 html,
 body {
   padding: 0;
@@ -10,4 +30,14 @@ body {
 
 * {
   box-sizing: border-box;
+}
+
+::selection {
+  background-color: rgb(var(--color-accent) / 0.3);
+  color: rgb(var(--color-fg));
+}
+
+:focus-visible {
+  outline: 2px solid rgb(var(--color-accent));
+  outline-offset: 2px;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 const defaultTheme = require("tailwindcss/defaultTheme");
-const withMT = require("@material-tailwind/react/utils/withMT");
 
-module.exports = withMT({
+module.exports = {
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx}",
     "./src/components/**/*.{js,ts,jsx,tsx}",
@@ -11,10 +10,21 @@ module.exports = withMT({
   darkMode: "class",
   theme: {
     extend: {
+      colors: {
+        bg: "rgb(var(--color-bg) / <alpha-value>)",
+        surface: "rgb(var(--color-surface) / <alpha-value>)",
+        border: "rgb(var(--color-border) / <alpha-value>)",
+        fg: "rgb(var(--color-fg) / <alpha-value>)",
+        "fg-muted": "rgb(var(--color-fg-muted) / <alpha-value>)",
+        accent: "rgb(var(--color-accent) / <alpha-value>)",
+        "accent-fg": "rgb(var(--color-accent-fg) / <alpha-value>)",
+      },
       fontFamily: {
-        sans: ["Inter var", ...defaultTheme.fontFamily.sans],
+        sans: ["var(--font-inter)", ...defaultTheme.fontFamily.sans],
+        display: ["var(--font-space-grotesk)", ...defaultTheme.fontFamily.sans],
+        mono: ["var(--font-jetbrains-mono)", ...defaultTheme.fontFamily.mono],
       },
     },
   },
   plugins: [],
-});
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,9 +16,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["src/components/*"],
-      "@/pages/*": ["src/pages/*"],
-      "@/styles/*": ["src/styles/*"]
+      "@/*": ["src/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "types.d.ts"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,18 +14,6 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@emotion/is-prop-valid@^0.8.2":
-  version "0.8.8"
-  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
-  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
-  dependencies:
-    "@emotion/memoize" "0.7.4"
-
-"@emotion/memoize@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
-  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
-
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
@@ -57,42 +45,6 @@
   version "8.57.0"
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
   integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
-
-"@floating-ui/core@^1.0.0":
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.6.1.tgz#a4e6fef1b069cda533cbc7a4998c083a37f37573"
-  integrity sha512-42UH54oPZHPdRHdw6BgoBD6cg/eVTmVrFcgeRDM3jbO7uxSoipVcmcIGFcA5jmOHO5apcyvBhkSKES3fQJnu7A==
-  dependencies:
-    "@floating-ui/utils" "^0.2.0"
-
-"@floating-ui/dom@^1.2.1":
-  version "1.6.4"
-  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.6.4.tgz#3a9d1f3b7ccdab89a4ca05713acc6204b1f67a29"
-  integrity sha512-0G8R+zOvQsAG1pg2Q99P21jiqxqGBW1iRe/iXHsBRBxnpXKFI8QwbB4x5KmYLggNO5m34IQgOIu9SCRfR/WWiQ==
-  dependencies:
-    "@floating-ui/core" "^1.0.0"
-    "@floating-ui/utils" "^0.2.0"
-
-"@floating-ui/react-dom@^1.2.2":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react-dom/-/react-dom-1.3.0.tgz#4d35d416eb19811c2b0e9271100a6aa18c1579b3"
-  integrity sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==
-  dependencies:
-    "@floating-ui/dom" "^1.2.1"
-
-"@floating-ui/react@0.19.0":
-  version "0.19.0"
-  resolved "https://registry.yarnpkg.com/@floating-ui/react/-/react-0.19.0.tgz#d8e19a3fcfaa0684d5ec3f335232b4e0ac0c87e1"
-  integrity sha512-fgYvN4ksCi5OvmPXkyOT8o5a8PSKHMzPHt+9mR6KYWdF16IAjWRLZPAAziI2sznaWT23drRFrYw64wdvYqqaQw==
-  dependencies:
-    "@floating-ui/react-dom" "^1.2.2"
-    aria-hidden "^1.1.3"
-    tabbable "^6.0.1"
-
-"@floating-ui/utils@^0.2.0":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@floating-ui/utils/-/utils-0.2.2.tgz#d8bae93ac8b815b2bd7a98078cf91e2724ef11e5"
-  integrity sha512-J4yDIIthosAsRZ5CPYP/jQvUAQtlZTTD/4suA08/FEnlxqW3sKS9iAhgsa9VYLZ6vDHn/ixJgIqRQPotoBjxIw==
 
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
@@ -156,74 +108,6 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
-
-"@material-tailwind/react@^2.1.9":
-  version "2.1.9"
-  resolved "https://registry.yarnpkg.com/@material-tailwind/react/-/react-2.1.9.tgz#d29bfa2f69a58708f85f22ce6ad798dbf1300c70"
-  integrity sha512-3uPlJE9yK4JF9DEQO4I1QbjR8o05+4fysLqoZ0v38TDOLE2tvDRhTBVhn6Mp9vSsq5CoJOKgemG7kbkOFAji4A==
-  dependencies:
-    "@floating-ui/react" "0.19.0"
-    classnames "2.3.2"
-    deepmerge "4.2.2"
-    framer-motion "6.5.1"
-    material-ripple-effects "2.0.1"
-    prop-types "15.8.1"
-    react "18.2.0"
-    react-dom "18.2.0"
-    tailwind-merge "1.8.1"
-
-"@motionone/animation@^10.12.0":
-  version "10.17.0"
-  resolved "https://registry.yarnpkg.com/@motionone/animation/-/animation-10.17.0.tgz#7633c6f684b5fee2b61c405881b8c24662c68fca"
-  integrity sha512-ANfIN9+iq1kGgsZxs+Nz96uiNcPLGTXwfNo2Xz/fcJXniPYpaz/Uyrfa+7I5BPLxCP82sh7quVDudf1GABqHbg==
-  dependencies:
-    "@motionone/easing" "^10.17.0"
-    "@motionone/types" "^10.17.0"
-    "@motionone/utils" "^10.17.0"
-    tslib "^2.3.1"
-
-"@motionone/dom@10.12.0":
-  version "10.12.0"
-  resolved "https://registry.yarnpkg.com/@motionone/dom/-/dom-10.12.0.tgz#ae30827fd53219efca4e1150a5ff2165c28351ed"
-  integrity sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==
-  dependencies:
-    "@motionone/animation" "^10.12.0"
-    "@motionone/generators" "^10.12.0"
-    "@motionone/types" "^10.12.0"
-    "@motionone/utils" "^10.12.0"
-    hey-listen "^1.0.8"
-    tslib "^2.3.1"
-
-"@motionone/easing@^10.17.0":
-  version "10.17.0"
-  resolved "https://registry.yarnpkg.com/@motionone/easing/-/easing-10.17.0.tgz#d66cecf7e3ee30104ad00389fb3f0b2282d81aa9"
-  integrity sha512-Bxe2wSuLu/qxqW4rBFS5m9tMLOw+QBh8v5A7Z5k4Ul4sTj5jAOfZG5R0bn5ywmk+Fs92Ij1feZ5pmC4TeXA8Tg==
-  dependencies:
-    "@motionone/utils" "^10.17.0"
-    tslib "^2.3.1"
-
-"@motionone/generators@^10.12.0":
-  version "10.17.0"
-  resolved "https://registry.yarnpkg.com/@motionone/generators/-/generators-10.17.0.tgz#878d292539c41434c13310d5f863a87a94e6e689"
-  integrity sha512-T6Uo5bDHrZWhIfxG/2Aut7qyWQyJIWehk6OB4qNvr/jwA/SRmixwbd7SOrxZi1z5rH3LIeFFBKK1xHnSbGPZSQ==
-  dependencies:
-    "@motionone/types" "^10.17.0"
-    "@motionone/utils" "^10.17.0"
-    tslib "^2.3.1"
-
-"@motionone/types@^10.12.0", "@motionone/types@^10.17.0":
-  version "10.17.0"
-  resolved "https://registry.yarnpkg.com/@motionone/types/-/types-10.17.0.tgz#179571ce98851bac78e19a1c3974767227f08ba3"
-  integrity sha512-EgeeqOZVdRUTEHq95Z3t8Rsirc7chN5xFAPMYFobx8TPubkEfRSm5xihmMUkbaR2ErKJTUw3347QDPTHIW12IA==
-
-"@motionone/utils@^10.12.0", "@motionone/utils@^10.17.0":
-  version "10.17.0"
-  resolved "https://registry.yarnpkg.com/@motionone/utils/-/utils-10.17.0.tgz#cc0ba8acdc6848ff48d8c1f2d0d3e7602f4f942e"
-  integrity sha512-bGwrki4896apMWIj9yp5rAS2m0xyhxblg6gTB/leWDPt+pb410W8lYWsxyurX+DH+gO1zsQsfx2su/c1/LtTpg==
-  dependencies:
-    "@motionone/types" "^10.17.0"
-    hey-listen "^1.0.8"
-    tslib "^2.3.1"
 
 "@next/env@14.2.5":
   version "14.2.5"
@@ -308,6 +192,127 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@radix-ui/primitive@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.4.tgz#47ef0f6cff4a1a1c09ebbf6d79159b7f01b967cf"
+  integrity sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==
+
+"@radix-ui/react-compose-refs@1.1.3", "@radix-ui/react-compose-refs@^1.1.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz#5f1e61e1a5f52800d31e7f8affa6d046e38f50d1"
+  integrity sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==
+
+"@radix-ui/react-context@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.4.tgz#5e39f26ebbefed27836e46e763e8f71e09999ccd"
+  integrity sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==
+
+"@radix-ui/react-dialog@^1.1.6":
+  version "1.1.18"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.18.tgz#790f89b25b36de3df184eacf028e2b72b7a6fdd1"
+  integrity sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==
+  dependencies:
+    "@radix-ui/primitive" "1.1.4"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-context" "1.1.4"
+    "@radix-ui/react-dismissable-layer" "1.1.14"
+    "@radix-ui/react-focus-guards" "1.1.4"
+    "@radix-ui/react-focus-scope" "1.1.11"
+    "@radix-ui/react-id" "1.1.2"
+    "@radix-ui/react-portal" "1.1.13"
+    "@radix-ui/react-presence" "1.1.6"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-slot" "1.3.0"
+    "@radix-ui/react-use-controllable-state" "1.2.3"
+    aria-hidden "^1.2.4"
+    react-remove-scroll "^2.7.2"
+
+"@radix-ui/react-dismissable-layer@1.1.14":
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.14.tgz#7d911f0c456463ac4af65fbcd356161d6512afb3"
+  integrity sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==
+  dependencies:
+    "@radix-ui/primitive" "1.1.4"
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+    "@radix-ui/react-use-effect-event" "0.0.3"
+
+"@radix-ui/react-focus-guards@1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz#3ef07a117ae7aa1430442aaebd766507e69d391c"
+  integrity sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==
+
+"@radix-ui/react-focus-scope@1.1.11":
+  version "1.1.11"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.11.tgz#d34a0a181842582ae0b82c2244672894debf33f9"
+  integrity sha512-Mn88Vg2whaRocGJNOH+DKFqYm6ySFPQaiwHNxZPyjn99B52KAEJWWY9NP83+nWdk2HM3rdov+STu9AG471Rt9w==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-callback-ref" "1.1.2"
+
+"@radix-ui/react-id@1.1.2", "@radix-ui/react-id@^1.1.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-id/-/react-id-1.1.2.tgz#6fe97e7289c7133b44f8c9c61fdddf2a6be1421d"
+  integrity sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-portal@1.1.13":
+  version "1.1.13"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.13.tgz#8b80b8b33ef4fff449c6d3ab62492f4dca162c7e"
+  integrity sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.7"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-presence@1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.6.tgz#f0edff4f119dbc8ef81611e539a8f58d9afb33c3"
+  integrity sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-primitive@2.1.7", "@radix-ui/react-primitive@^2.0.2":
+  version "2.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.1.7.tgz#1f487a06434770f865dbfb6c9a55bbefcbad8c82"
+  integrity sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==
+  dependencies:
+    "@radix-ui/react-slot" "1.3.0"
+
+"@radix-ui/react-slot@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.3.0.tgz#e311c7a6c8d65b1af9e69af8e3318c6c7105a212"
+  integrity sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.3"
+
+"@radix-ui/react-use-callback-ref@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz#ddc0bc1381ff3b62368c248808efc45a098bafde"
+  integrity sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==
+
+"@radix-ui/react-use-controllable-state@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz#516996f6443207546aa15a59bc71cdf5b54e01d1"
+  integrity sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==
+  dependencies:
+    "@radix-ui/react-use-effect-event" "0.0.3"
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-use-effect-event@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz#e8f45e8e6ef64ce5bea7b5a9effc373f067e3530"
+  integrity sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==
+  dependencies:
+    "@radix-ui/react-use-layout-effect" "1.1.2"
+
+"@radix-ui/react-use-layout-effect@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz#c882e66497174d061f250e65251974b699c65b65"
+  integrity sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==
+
 "@rushstack/eslint-patch@^1.3.3":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.10.2.tgz#053f1540703faa81dea2966b768ee5581c66aeda"
@@ -325,6 +330,11 @@
   dependencies:
     "@swc/counter" "^0.1.3"
     tslib "^2.4.0"
+
+"@types/canvas-confetti@^1.9.0":
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/@types/canvas-confetti/-/canvas-confetti-1.9.0.tgz#d1077752e046413c9881fbb2ba34a70ebe3c1773"
+  integrity sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -474,10 +484,10 @@ argparse@^2.0.1:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
   integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
-aria-hidden@^1.1.3:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.4.tgz#b78e383fdbc04d05762c78b4a25a501e736c4522"
-  integrity sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==
+aria-hidden@^1.2.4:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/aria-hidden/-/aria-hidden-1.2.6.tgz#73051c9b088114c795b1ea414e9c0fff874ffc1a"
+  integrity sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==
   dependencies:
     tslib "^2.0.0"
 
@@ -756,6 +766,11 @@ caniuse-lite@^1.0.30001646:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz#52de59529e8b02b1aedcaaf5c05d9e23c0c28138"
   integrity sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==
 
+canvas-confetti@^1.9.4:
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/canvas-confetti/-/canvas-confetti-1.9.4.tgz#4412a5daa96afd0b4d70ecd66b65ce8db3022b2b"
+  integrity sha512-yxQbJkAVrFXWNbTUjPqjF7G+g6pDotOUHGbkZq2NELZUMDpiJ85rIEazVb8GTaAptNW2miJAXbs1BtioA251Pw==
+
 chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
@@ -779,15 +794,20 @@ chokidar@^3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-classnames@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
-  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
-
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
+
+cmdk@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/cmdk/-/cmdk-1.1.1.tgz#b8524272699ccaa37aaf07f36850b376bf3d58e5"
+  integrity sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "^1.1.1"
+    "@radix-ui/react-dialog" "^1.1.6"
+    "@radix-ui/react-id" "^1.1.0"
+    "@radix-ui/react-primitive" "^2.0.2"
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -905,11 +925,6 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
-deepmerge@4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
-  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
-
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
@@ -940,6 +955,11 @@ dequal@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
   integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
+detect-node-es@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/detect-node-es/-/detect-node-es-1.1.0.tgz#163acdf643330caa0b4cd7c21e7ee7755d6fa493"
+  integrity sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==
 
 didyoumean@^1.2.2:
   version "1.2.2"
@@ -1503,26 +1523,14 @@ fraction.js@^4.3.7:
   resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.3.7.tgz#06ca0085157e42fda7f9e726e79fefc4068840f7"
   integrity sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==
 
-framer-motion@6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-6.5.1.tgz#802448a16a6eb764124bf36d8cbdfa6dd6b931a7"
-  integrity sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==
+framer-motion@^12.42.2:
+  version "12.42.2"
+  resolved "https://registry.yarnpkg.com/framer-motion/-/framer-motion-12.42.2.tgz#8628ad31a9b5c1ea6f908ea1764784e33870b711"
+  integrity sha512-5XY9luDiu0oHfHBjpDthFMh0ES+122w6p/papSJBweMkO8Sn+PW2QaEgRblQBpWFnuvZS5qvarpt/hO2pjGmnw==
   dependencies:
-    "@motionone/dom" "10.12.0"
-    framesync "6.0.1"
-    hey-listen "^1.0.8"
-    popmotion "11.0.3"
-    style-value-types "5.0.0"
-    tslib "^2.1.0"
-  optionalDependencies:
-    "@emotion/is-prop-valid" "^0.8.2"
-
-framesync@6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/framesync/-/framesync-6.0.1.tgz#5e32fc01f1c42b39c654c35b16440e07a25d6f20"
-  integrity sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==
-  dependencies:
-    tslib "^2.1.0"
+    motion-dom "^12.42.2"
+    motion-utils "^12.39.0"
+    tslib "^2.4.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1588,6 +1596,11 @@ get-intrinsic@^1.2.1, get-intrinsic@^1.2.2, get-intrinsic@^1.2.3, get-intrinsic@
     has-proto "^1.0.1"
     has-symbols "^1.0.3"
     hasown "^2.0.0"
+
+get-nonce@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-nonce/-/get-nonce-1.0.1.tgz#fdf3f0278073820d2ce9426c18f07481b1e0cdf3"
+  integrity sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==
 
 get-symbol-description@^1.0.0:
   version "1.0.0"
@@ -1766,11 +1779,6 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
-
-hey-listen@^1.0.8:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/hey-listen/-/hey-listen-1.0.8.tgz#8e59561ff724908de1aa924ed6ecc84a56a9aa68"
-  integrity sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q==
 
 husky@9.0.11:
   version "9.0.11"
@@ -2133,6 +2141,11 @@ language-tags@^1.0.9:
   dependencies:
     language-subtag-registry "^0.3.20"
 
+lenis@^1.3.25:
+  version "1.3.25"
+  resolved "https://registry.yarnpkg.com/lenis/-/lenis-1.3.25.tgz#9336d9a754d8d9c454b86e9576328f5448321bd7"
+  integrity sha512-mOKxayErlaONK8fm4LN3XNd99Qu4plTpn9h9qf8wxzjGrJDzuD84FYzZ81HCd6ZsWp++VWVwOzL286Pf2s2u4A==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -2192,11 +2205,6 @@ lucide-react@^0.378.0:
   resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.378.0.tgz#232acb99c6baedfa90959a2c0dd11327b058bde8"
   integrity sha512-u6EPU8juLUk9ytRcyapkWI18epAv3RU+6+TC23ivjR0e+glWKBobFeSgRwOIJihzktILQuy6E0E80P2jVTDR5g==
 
-material-ripple-effects@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/material-ripple-effects/-/material-ripple-effects-2.0.1.tgz#47803d2ab1561698d930e2524a7a9a19fb2829b7"
-  integrity sha512-hHlUkZAuXbP94lu02VgrPidbZ3hBtgXBtjlwR8APNqOIgDZMV8MCIcsclL8FmGJQHvnORyvoQgC965vPsiyXLQ==
-
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
@@ -2240,6 +2248,26 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "7.0.4"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.0.4.tgz#dbce03740f50a4786ba994c1fb908844d27b038c"
   integrity sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==
+
+motion-dom@^12.42.2:
+  version "12.42.2"
+  resolved "https://registry.yarnpkg.com/motion-dom/-/motion-dom-12.42.2.tgz#b4661b9b3394ae7e990d76dc954bc1e321c59305"
+  integrity sha512-5gIMWLp/PycBtJRJWRgjxke5n8dlvkSn2DrYW+tr3XcqAZY1xZh6BJyooJXCM8wdfM7wfMjkBJNLge1CKPUIRA==
+  dependencies:
+    motion-utils "^12.39.0"
+
+motion-utils@^12.39.0:
+  version "12.39.0"
+  resolved "https://registry.yarnpkg.com/motion-utils/-/motion-utils-12.39.0.tgz#e1c66f0e912999804bc5e69b4630c3bc794ef29f"
+  integrity sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==
+
+motion@^12.42.2:
+  version "12.42.2"
+  resolved "https://registry.yarnpkg.com/motion/-/motion-12.42.2.tgz#7a0954acb1975e1899ad65639a46fc12a3d24999"
+  integrity sha512-Atvv11yUKIid41cVrRBDVX5m8tF8kNpExRSlbpt6APClhDjtwQssgFHhQzejxw7/7YYbjHSPKBVbHo05BuJT5Q==
+  dependencies:
+    framer-motion "^12.42.2"
+    tslib "^2.4.0"
 
 ms@2.1.2:
   version "2.1.2"
@@ -2524,16 +2552,6 @@ pirates@^4.0.1:
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.6.tgz#3018ae32ecfcff6c29ba2267cbf21166ac1f36b9"
   integrity sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==
 
-popmotion@11.0.3:
-  version "11.0.3"
-  resolved "https://registry.yarnpkg.com/popmotion/-/popmotion-11.0.3.tgz#565c5f6590bbcddab7a33a074bb2ba97e24b0cc9"
-  integrity sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==
-  dependencies:
-    framesync "6.0.1"
-    hey-listen "^1.0.8"
-    style-value-types "5.0.0"
-    tslib "^2.1.0"
-
 possible-typed-array-names@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz#89bb63c6fada2c3e90adc4a647beeeb39cc7bf8f"
@@ -2616,7 +2634,7 @@ prettier@3.3.3:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
   integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
-prop-types@15.8.1, prop-types@^15.8.1:
+prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -2635,14 +2653,6 @@ queue-microtask@^1.2.2:
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
 
-react-dom@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.2.0.tgz#22aaf38708db2674ed9ada224ca4aa708d821e3d"
-  integrity sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==
-  dependencies:
-    loose-envify "^1.1.0"
-    scheduler "^0.23.0"
-
 react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -2656,12 +2666,32 @@ react-is@^16.13.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react@18.2.0:
-  version "18.2.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
-  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
   dependencies:
-    loose-envify "^1.1.0"
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
+react-remove-scroll@^2.7.2:
+  version "2.7.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz#6442da56791117661978ae99cd29be9026fecca0"
+  integrity sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.3"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
+    use-sidecar "^1.1.3"
+
+react-style-singleton@^2.2.2, react-style-singleton@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
+    tslib "^2.0.0"
 
 react@^18.3.1:
   version "18.3.1"
@@ -2796,7 +2826,7 @@ safe-regex-test@^1.0.3:
     es-errors "^1.3.0"
     is-regex "^1.1.4"
 
-scheduler@^0.23.0, scheduler@^0.23.2:
+scheduler@^0.23.2:
   version "0.23.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.23.2.tgz#414ba64a3b282892e944cf2108ecc078d115cdc3"
   integrity sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==
@@ -2905,8 +2935,16 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
-  name string-width-cjs
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2996,7 +3034,14 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3019,14 +3064,6 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
-
-style-value-types@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/style-value-types/-/style-value-types-5.0.0.tgz#76c35f0e579843d523187989da866729411fc8ad"
-  integrity sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==
-  dependencies:
-    hey-listen "^1.0.8"
-    tslib "^2.1.0"
 
 styled-jsx@5.1.1:
   version "5.1.1"
@@ -3059,16 +3096,6 @@ supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
-
-tabbable@^6.0.1:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
-  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
-
-tailwind-merge@1.8.1:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/tailwind-merge/-/tailwind-merge-1.8.1.tgz#0e56c8afbab2491f72e06381043ffec8b720ba04"
-  integrity sha512-+fflfPxvHFr81hTJpQ3MIwtqgvefHZFUHFiIHpVIRXvG/nX9+gu2P7JNlFu2bfDMJ+uHhi/pUgzaYacMoXv+Ww==
 
 tailwindcss@3.4.9:
   version "3.4.9"
@@ -3149,10 +3176,10 @@ tsconfig-paths@^3.15.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.0, tslib@^2.1.0, tslib@^2.3.1:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
-  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+tslib@^2.0.0, tslib@^2.1.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tslib@^2.4.0:
   version "2.4.1"
@@ -3249,6 +3276,21 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
+  dependencies:
+    tslib "^2.0.0"
+
+use-sidecar@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.1.3.tgz#10e7fd897d130b896e2c546c63a5e8233d00efdb"
+  integrity sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==
+  dependencies:
+    detect-node-es "^1.1.0"
+    tslib "^2.0.0"
 
 util-deprecate@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Summary
- New design token foundation (Material Tailwind removed)
- Full site rebuilt: Hero, About, Skills, Projects, Experience, Contact sections
- Command palette, easter eggs, smooth scroll (Lenis), custom 404 page
- Accessibility fixes (WCAG 2.2.2 role cycling, disclosure panel mount guard, palette hint labeling)
- Header nav fixes (works off home page, compact on small screens)
- Code-review cleanup pass

## Test plan
- [ ] `npm run build` passes
- [ ] Manual pass: nav on home + other pages, command palette, 404 page, mobile widths