### PR TITLE
feat: polish redesign follow-ups

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -40,7 +40,9 @@ export const Footer: FC = () => {
         </div>
       </div>
 
-      <p className="pb-4 text-center font-mono text-xs text-fg-muted sm:pb-6">Built with care in London · Next.js</p>
+      <p className="pb-4 text-center font-mono text-xs text-fg-muted sm:pb-6">
+        Built with love, caffeine & AI collaboration
+      </p>
     </footer>
   );
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -14,7 +14,7 @@ const NAV_LINKS: [string, string][] = [
 
 export const Header: FC = () => {
   return (
-    <header className="sticky top-0 z-40 w-full border-b border-border bg-bg/85 backdrop-blur-md">
+    <header className="sticky top-0 z-40 w-full border-b border-border bg-bg/85 font-sans backdrop-blur-md">
       <div className="container mx-auto flex items-center justify-between py-2 pl-4 sm:flex-row sm:p-6">
         <section className="flex items-center">
           <Link href="/#home" aria-label="Marco Escaleira — home" className="shrink-0">

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -68,10 +68,10 @@ export const Layout = ({ children }: PropsWithChildren) => {
       </Head>
 
       <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
-        <div className={`${FONT_VARIABLES} flex h-full min-h-screen w-full flex-col bg-bg text-fg`}>
+        <div className={`${FONT_VARIABLES} flex h-full min-h-screen w-full flex-col bg-bg font-sans text-fg`}>
           <Header />
 
-          <main className="flex flex-1 justify-center font-sans">{children}</main>
+          <main className="flex flex-1 justify-center">{children}</main>
 
           <Footer />
         </div>

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -8,8 +8,6 @@ import { scrollToSection } from "@/components/SmoothScroll";
 
 const ROLE_WORDS = ["React Native", "payments", "design systems", "Node & AWS"];
 
-const LONGEST_ROLE_WORD = ROLE_WORDS.reduce((longest, word) => (word.length > longest.length ? word : longest));
-
 const SOCIAL_LINKS = [
   { href: "https://github.com/MarcoEscaleira", label: "GitHub", icon: Github },
   { href: "https://www.linkedin.com/in/marco-escaleira00/", label: "LinkedIn", icon: Linkedin },
@@ -54,24 +52,20 @@ const RoleCycle = () => {
     return <span className="text-accent">{ROLE_WORDS[0]}</span>;
   }
 
+  // Size to the active word so the surrounding sentence stays tightly spaced.
   return (
-    <span className="relative inline-block h-[1.2em] align-bottom">
-      <span className="invisible" aria-hidden="true">
-        {LONGEST_ROLE_WORD}
-      </span>
-      <AnimatePresence mode="wait">
-        <motion.span
-          key={ROLE_WORDS[index]}
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          transition={{ duration: 0.35, ease: EASE_OUT_EXPO }}
-          className="absolute left-0 top-0 whitespace-nowrap text-accent"
-        >
-          {ROLE_WORDS[index]}
-        </motion.span>
-      </AnimatePresence>
-    </span>
+    <AnimatePresence mode="wait" initial={false}>
+      <motion.span
+        key={ROLE_WORDS[index]}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -8 }}
+        transition={{ duration: 0.3, ease: EASE_OUT_EXPO }}
+        className="inline-block whitespace-nowrap text-accent"
+      >
+        {ROLE_WORDS[index]}
+      </motion.span>
+    </AnimatePresence>
   );
 };
 
@@ -192,6 +186,7 @@ export const Hero = () => {
               alt="Portrait of Marco Escaleira"
               width={220}
               height={220}
+              priority
               className="relative h-[200px] w-[200px] rounded-full border-4 border-surface object-cover sm:h-[220px] sm:w-[220px]"
             />
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,6 +43,7 @@ body {
   padding: 0;
   margin: 0;
   line-height: 1.55;
+  font-family: var(--font-atkinson), ui-sans-serif, system-ui, sans-serif;
 }
 
 .dark body {


### PR DESCRIPTION
## Summary
- Fix header/body font inheritance so nav uses Atkinson Hyperlegible (not Times)
- Tighten hero role-cycle spacing so the “Right now” line reads as one sentence
- Update footer tagline to “Built with love, caffeine & AI collaboration”
- Keep hero image `priority` and shell `font-sans` / body font-family fallbacks

## Test plan
- [ ] Hard-refresh homepage; header nav matches body sans font (light + dark)
- [ ] Watch role words cycle — no large gap before “at yetipay”
- [ ] Confirm footer copy
- [ ] Mobile + desktop quick pass