### PR TITLE
feat(content): align portfolio messaging with CV narrative

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   },
   "scripts": {
     "prepare": "husky install",
-    "start:dev": "next dev",
+    "start:dev": "next dev -p 4567",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 4567",
     "lint": "next lint --fix",
     "release": "node scripts/release.mjs"
   },

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -67,7 +67,11 @@ export const Layout = ({ children }: PropsWithChildren) => {
   return (
     <>
       <Head>
-        <title>Marco Escaleira</title>
+        <title>Marco Escaleira — Software Engineer</title>
+        <meta
+          name="description"
+          content="Full-stack software engineer with 7+ years shipping scalable web and mobile products — React, React Native, Node.js, and AWS."
+        />
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/favicon-16x16.png" sizes="16x16" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -22,7 +22,7 @@ export const About = () => {
         <SectionHeading
           index="01."
           title="About"
-          eyebrow="Portugal roots, London base — still curious about how products actually land in people's hands."
+          eyebrow="Portugal roots, London base — building products people actually use."
         />
 
         <div className="grid grid-cols-1 gap-xl md:grid-cols-[1.4fr_1fr]">
@@ -38,12 +38,13 @@ export const About = () => {
               the Faculty of Medicine in Porto. I taught at Mindera Academy, then moved from Porto to London.
             </p>
             <p>
-              These days I build payment products at yetipay — most recently Tap to Pay on iPhone and Android — and I
-              carry the on-call pager for a live payments platform. That part is its own kind of education.
+              I build production-ready products from frontend to backend — owning architecture, infrastructure,
+              developer experience, and customer-facing features. I enjoy shipping scalable software while improving
+              engineering velocity through automation, testing, and reusable systems.
             </p>
             <p className="rounded-md border border-border bg-surface px-4 py-3 font-mono text-sm text-fg">
-              <span className="text-accent">Currently:</span> shipping the yetipay merchant app in React Native, with
-              Tap to Pay on both iOS and Android.
+              <span className="text-accent">Currently:</span> shipping payments products at yetipay end to end —
+              merchant app, APIs, AWS, and on-call for a live platform.
             </p>
           </motion.div>
 

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -24,7 +24,7 @@ export const Contact = () => {
         <SectionHeading
           index="05."
           title="Contact"
-          eyebrow="Got a role, a project, or just want to talk shop? My inbox is open."
+          eyebrow="Hiring for full-stack, payments, or production engineering work? My inbox is open."
         />
 
         <motion.div
@@ -35,8 +35,8 @@ export const Contact = () => {
           className="rounded-lg border border-border bg-surface px-6 py-10 sm:px-10"
         >
           <p className="max-w-prose text-fg-muted">
-            If you&apos;re hiring or building something in payments, mobile, or product engineering — I&apos;d like to
-            hear from you.
+            If you&apos;re hiring or building something across web, mobile, or backend — full-stack work with real
+            production ownership — I&apos;d like to hear from you.
           </p>
 
           <Link

--- a/src/components/sections/Experience.tsx
+++ b/src/components/sections/Experience.tsx
@@ -17,25 +17,38 @@ export const Experience = () => {
         <SectionHeading
           index="02."
           title="Experience"
-          eyebrow="Where I've shipped, mentored, and learned — from faculty web work to live payments."
+          eyebrow="End-to-end ownership — from faculty web work to production payments, on-call included."
         />
 
         <ol className="relative space-y-xl border-l border-border pl-8 sm:pl-10">
-          {experience.map(({ company, role, location, period, highlights, url }) => (
+          {experience.map(({ company, role, location, period, highlights, url, flagship }) => (
             <motion.li
               key={company}
               initial="hidden"
               whileInView="show"
-              viewport={{ once: true, amount: 0.3 }}
+              viewport={{ once: true, amount: 0.2 }}
               variants={entry}
-              className="relative"
+              className={`relative ${
+                flagship
+                  ? "-ml-2 rounded-lg border border-accent/50 bg-surface px-5 py-5 sm:-ml-3 sm:px-6 sm:py-6"
+                  : ""
+              }`}
             >
               <span
                 aria-hidden
-                className="absolute -left-[2.35rem] top-1.5 size-3 rounded-full border-2 border-accent bg-bg sm:-left-[2.85rem]"
+                className={`absolute top-1.5 size-3 rounded-full border-2 border-accent bg-bg ${
+                  flagship
+                    ? "-left-[2.85rem] sm:-left-[3.35rem]"
+                    : "-left-[2.35rem] sm:-left-[2.85rem]"
+                }`}
               />
 
               <div className="flex flex-wrap items-baseline gap-x-sm gap-y-2xs">
+                {flagship && (
+                  <span className="rounded-full bg-accent px-2.5 py-0.5 font-mono text-xs font-medium text-accent-fg">
+                    Flagship
+                  </span>
+                )}
                 <h3 className="font-display text-display-sm font-semibold">
                   {url ? (
                     <Link

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import { EASE_OUT_EXPO } from "@/components/sections/SectionHeading";
 import { scrollToSection } from "@/components/SmoothScroll";
 
-const ROLE_WORDS = ["React Native", "payments", "design systems", "Node & AWS"];
+const ROLE_WORDS = ["Software Engineer", "Fullstack Engineer"];
 
 const SOCIAL_LINKS = [
   { href: "https://github.com/MarcoEscaleira", label: "GitHub", icon: Github },
@@ -61,7 +61,7 @@ const RoleCycle = () => {
         animate={{ opacity: 1, y: 0 }}
         exit={{ opacity: 0, y: -8 }}
         transition={{ duration: 0.3, ease: EASE_OUT_EXPO }}
-        className="inline-block whitespace-nowrap text-accent"
+        className="inline-block text-accent"
       >
         {ROLE_WORDS[index]}
       </motion.span>
@@ -116,7 +116,8 @@ export const Hero = () => {
           </motion.h1>
 
           <motion.p variants={item} className="mt-md max-w-prose text-lg text-fg-muted sm:text-xl">
-            Full-stack engineer who builds products people actually use — React, React Native, Node, AWS.
+            Full-stack software engineer with 7+ years shipping scalable web and mobile products end to end —
+            React, React Native, Node.js, and AWS — from architecture to production.
           </motion.p>
 
           <motion.p variants={item} className="mt-xs max-w-prose text-base text-fg-muted">

--- a/src/components/sections/Metrics.tsx
+++ b/src/components/sections/Metrics.tsx
@@ -1,0 +1,38 @@
+import { motion, useReducedMotion } from "motion/react";
+import { EASE_OUT_EXPO } from "@/components/sections/SectionHeading";
+import { metrics } from "@/data/metrics";
+
+export const Metrics = () => {
+  const shouldReduceMotion = useReducedMotion();
+
+  const list = {
+    hidden: {},
+    show: { transition: { staggerChildren: shouldReduceMotion ? 0 : 0.06 } },
+  };
+
+  const item = {
+    hidden: shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 12 },
+    show: { opacity: 1, y: 0, transition: { duration: 0.45, ease: EASE_OUT_EXPO } },
+  };
+
+  return (
+    <section aria-label="Key metrics" className="w-full bg-surface/60 py-lg">
+      <div className="mx-auto w-full max-w-5xl px-6">
+        <motion.ul
+          initial="hidden"
+          whileInView="show"
+          viewport={{ once: true, amount: 0.4 }}
+          variants={list}
+          className="grid grid-cols-2 gap-sm sm:grid-cols-3 lg:grid-cols-7 lg:gap-md"
+        >
+          {metrics.map(({ value, label }) => (
+            <motion.li key={label} variants={item} className="min-w-0">
+              <p className="font-display text-xl font-semibold text-fg sm:text-2xl">{value}</p>
+              <p className="mt-3xs font-mono text-xs text-fg-muted">{label}</p>
+            </motion.li>
+          ))}
+        </motion.ul>
+      </div>
+    </section>
+  );
+};

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -155,7 +155,7 @@ export const Projects = () => {
         <SectionHeading
           index="03."
           title="Projects"
-          eyebrow="Real products, real constraints — open a card for problem, build, and outcome."
+          eyebrow="Real products, real constraints — open a card for problem, who benefited, and impact."
         />
 
         <motion.div

--- a/src/components/sections/Skills.tsx
+++ b/src/components/sections/Skills.tsx
@@ -21,7 +21,7 @@ export const Skills = () => {
         <SectionHeading
           index="04."
           title="Skills"
-          eyebrow="Tools I reach for when the work needs to ship — not a laundry list."
+          eyebrow="The stack I reach for when shipping production software — not a laundry list."
         />
 
         <div className="space-y-lg">

--- a/src/components/sections/index.ts
+++ b/src/components/sections/index.ts
@@ -1,4 +1,5 @@
 export { Hero } from "./Hero";
+export { Metrics } from "./Metrics";
 export { About } from "./About";
 export { Projects } from "./Projects";
 export { Experience } from "./Experience";

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -7,44 +7,69 @@ export interface Experience {
   period: string;
   highlights: string[];
   url?: string;
+  flagship?: boolean;
 }
 
 export const experience: Experience[] = [
   {
     company: "yetipay",
-    role: "Software Engineer",
+    role: "Fullstack Engineer",
     location: "London, UK",
     period: "Current",
+    flagship: true,
     highlights: [
-      "Shipped Tap to Pay for merchants on iPhone and Android with React Native",
-      "Made CI/CD pipelines ~10× faster",
-      "Grew the design system across the product",
-      "On-call for a live payments platform",
+      "Built the React Native merchant app from scratch — Tap to Pay on iPhone and Android, unlocking new payment capabilities for merchants",
+      "Designed and implemented backend APIs powering production payment flows",
+      "Owned and maintained AWS infrastructure for a live payments platform",
+      "Operated production systems: on-call rotations, incident response, and debugging live issues",
+      "Built scalable internal architecture shared across product surfaces",
+      "Partnered closely with Design and Product to ship customer-facing features",
+      "Introduced an automated E2E testing strategy that raised release confidence",
+      "Cut CI/CD runtime by ~10×, unblocking faster iteration across the team",
+      "Grew a reusable design system that improved engineering velocity",
     ],
     url: "https://yetipay.me",
   },
   {
     company: "Beacon",
     role: "Software Engineer",
-    period: "",
-    highlights: ["Improved page-load performance by ~50%"],
+    location: "London, UK",
+    period: "Mar 2022 – Aug 2024",
+    highlights: [
+      "Designed a future-proof architecture for the core shipment-tracking feature",
+      "Integrated Chromatic visual testing so UI stayed consistent across releases",
+      "Improved page-load performance by ~50% for a lighter, faster app on devices",
+      "Built PoCs that helped steer key product decisions",
+      "Built a backoffice app that became part of Ops workflows and automated BAU work",
+      "Joined on-call rotations — supported production systems and resolved live incidents",
+    ],
+  },
+  {
+    company: "Mindera Academy",
+    role: "Front End Teacher",
+    location: "Remote · alongside Beacon",
+    period: "Jun 2023 – Dec 2023",
+    highlights: [
+      "Built and delivered Front End 101 lesson plans for aspiring developers",
+      "Created learning resources — reading materials and coding exercises",
+      "Ran live coding sessions tying concepts to real-world product work",
+    ],
   },
   {
     company: "Mindera",
     role: "Software Engineer",
-    period: "",
-    highlights: ["Built React product features", "Defined an end-to-end testing strategy with Gherkin/Cucumber-style E2E tests"],
-  },
-  {
-    company: "Mindera Academy",
-    role: "Mentor / Teacher",
-    period: "",
-    highlights: ["Taught and mentored aspiring developers"],
+    location: "Porto, Portugal · TVG / FanDuel",
+    period: "Sep 2019 – Mar 2022",
+    highlights: [
+      "Implemented a monorepo with custom tooling and CI/CD that improved team delivery efficiency",
+      "Owned a challenging TVG / FanDuel project spanning micro-frontends and mobile apps — React, React Native, Redux, GraphQL",
+      "Led and assisted in technical interviews",
+    ],
   },
   {
     company: "FMUP (Faculty of Medicine, University of Porto)",
     role: "Early-career developer",
     period: "",
-    highlights: ["First professional steps — web work for the faculty"],
+    highlights: ["First professional steps — web work that served faculty staff and students"],
   },
 ];

--- a/src/data/metrics.ts
+++ b/src/data/metrics.ts
@@ -1,0 +1,14 @@
+export interface Metric {
+  value: string;
+  label: string;
+}
+
+export const metrics: Metric[] = [
+  { value: "7+", label: "Years experience" },
+  { value: "From scratch", label: "Merchant app shipped" },
+  { value: "10×", label: "CI/CD faster" },
+  { value: "~50%", label: "Faster page loads" },
+  { value: "AWS", label: "Infra ownership" },
+  { value: "On-call", label: "Production engineer" },
+  { value: "E2E", label: "Testing introduced" },
+];

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -21,13 +21,14 @@ export const projects: Project[] = [
   {
     slug: "yetipay-merchant-app",
     title: "yetipay Merchant App",
-    tagline: "Tap to Pay on your phone — no extra hardware required.",
-    problem: "Small merchants need to take card payments without buying extra hardware.",
+    tagline: "New payment capabilities for merchants — no extra hardware required.",
+    problem:
+      "Small merchants needed to take card payments without buying dedicated hardware, limiting how they could grow revenue.",
     built:
-      "A React Native merchant app with Tap to Pay on both iPhone and Android, plus card reader integration for merchants who want it. It's backed by an AWS payments platform underneath. This is my day job at yetipay, and it's live in merchants' hands.",
-    stack: ["React Native", "TypeScript", "iOS/Android Tap to Pay", "AWS"],
+      "Merchant-facing Tap to Pay on iPhone and Android, plus card reader support for those who want it. Designed the backend services and AWS platform underneath so payments stay reliable in production. Day job at yetipay — live in merchants' hands.",
+    stack: ["React Native", "TypeScript", "iOS/Android Tap to Pay", "Node.js", "AWS"],
     outcome:
-      "A live, in-production payments platform merchants use today to take card payments straight from their phone.",
+      "A production payments product merchants use today — new revenue opportunities without extra hardware, backed by scalable backend services.",
     links: {
       company: "https://yetipay.me",
     },
@@ -36,13 +37,14 @@ export const projects: Project[] = [
   {
     slug: "meet-the-countries",
     title: "Meet The Countries",
-    tagline: "One product, three codebases, zero excuses.",
-    problem: "Wanted to prove I could own a full product end to end — web, API, and mobile — not just one layer of it.",
+    tagline: "One product vision — web, API, and mobile — owned end to end.",
+    problem:
+      "Wanted proof of owning a full product across every layer, not just one surface — and shipping it with the same discipline as production work.",
     built:
-      "A full-stack side project spanning a TypeScript/React frontend, a Node/Express/GraphQL/MongoDB backend running in Docker, and a React Native/Expo mobile app. All three share the same product vision, with CI/CD pipelines and Gherkin-driven E2E tests keeping everything honest.",
+      "A full-stack product spanning a TypeScript/React web app, a Node/Express/GraphQL/MongoDB API in Docker, and a React Native/Expo mobile app. CI/CD and Gherkin-driven E2E tests keep releases honest across all three.",
     stack: ["TypeScript", "React", "Node.js", "Express", "GraphQL", "MongoDB", "Docker", "React Native", "Expo"],
     outcome:
-      "A shipped, live product across web and mobile, with automated tests and pipelines doing the boring work for me.",
+      "A live product across web and mobile, with automated tests and pipelines carrying the operational load — end-to-end ownership from idea to ship.",
     links: {
       live: "https://meetthecountries.com",
       repo: "https://github.com/MarcoEscaleira/meetthecountries-frontend",
@@ -53,12 +55,14 @@ export const projects: Project[] = [
   {
     slug: "motojoy",
     title: "MotoJoy",
-    tagline: "Where I started — and I'm not embarrassed about it.",
-    problem: "Learning how a real e-commerce store actually works: storefront, cart, checkout, backoffice, all of it.",
+    tagline: "Where I learned how a real store actually works.",
+    problem:
+      "Needed to understand the full commerce loop — storefront, cart, checkout, and backoffice — by building one that could take real payments.",
     built:
-      "A PHP, jQuery, and Bootstrap e-commerce site with a storefront, shopping cart, backoffice for managing it all, and PayPal integration for actual payments. It's not fancy by today's standards, and that's exactly the point.",
+      "An e-commerce site with storefront, shopping cart, admin backoffice, and PayPal checkout. PHP, jQuery, and Bootstrap — not fancy by today's standards, and that's the point.",
     stack: ["PHP", "jQuery", "Bootstrap", "PayPal"],
-    outcome: "My first real end-to-end build — the project that taught me most of what came after.",
+    outcome:
+      "A working end-to-end commerce flow that taught the fundamentals everything since has built on.",
     links: {
       repo: "https://github.com/MarcoEscaleira/motojoy",
     },
@@ -66,12 +70,11 @@ export const projects: Project[] = [
   {
     slug: "should-you-do-it",
     title: "shouldYouDoIt",
-    tagline: "Can't decide? Let the app decide for you.",
-    problem: "Sometimes you just need something to make the call for you.",
-    built:
-      "A tiny, playful TypeScript app that makes decisions so you don't have to. No accounts, no config, just an answer.",
+    tagline: "Can't decide? Let the app make the call.",
+    problem: "Sometimes you need a tiny tool that removes decision friction — no accounts, no setup.",
+    built: "A playful TypeScript app that answers yes-or-no so you don't have to. One job, done with a smile.",
     stack: ["TypeScript"],
-    outcome: "A small, fun, live tool that does exactly one thing and does it with a smile.",
+    outcome: "A live, zero-friction decision helper that does exactly one thing well.",
     links: {
       repo: "https://github.com/MarcoEscaleira/shouldyoudoit",
       live: "https://shouldyoudoit.surge.sh/",

--- a/src/data/skills.ts
+++ b/src/data/skills.ts
@@ -5,27 +5,23 @@ export interface SkillGroup {
 
 export const skills: SkillGroup[] = [
   {
-    label: "Languages",
-    skills: ["TypeScript", "JavaScript", "HTML", "CSS", "PHP"],
+    label: "Core",
+    skills: ["TypeScript", "React", "React Native", "Node.js", "GraphQL"],
   },
   {
-    label: "Frontend",
-    skills: ["React", "Next.js", "Tailwind CSS", "GraphQL (Apollo)"],
+    label: "AWS & Cloud",
+    skills: ["Lambda", "EventBridge", "CloudWatch", "Cognito", "Serverless", "Docker", "Microservices"],
   },
   {
-    label: "Mobile",
-    skills: ["React Native", "Expo", "Tap to Pay (iOS & Android)"],
+    label: "Data",
+    skills: ["SQL", "MongoDB", "DynamoDB"],
   },
   {
-    label: "Backend",
-    skills: ["Node.js", "Express", "MongoDB", "REST & GraphQL APIs"],
+    label: "Delivery & Quality",
+    skills: ["CI/CD", "E2E Testing", "Monorepo Architecture", "Git", "Agile"],
   },
   {
-    label: "AWS & Infra",
-    skills: ["AWS", "Docker", "CI/CD (GitHub Actions)", "Vercel"],
-  },
-  {
-    label: "Tooling & Testing",
-    skills: ["Jest", "E2E testing (Gherkin/Cucumber)", "Git", "Storybook-style design systems"],
+    label: "Craft",
+    skills: ["Design Systems", "AI-assisted engineering"],
   },
 ];

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
-import { About, Contact, Experience, Hero, Projects, Skills } from "@/components/sections";
+import { About, Contact, Experience, Hero, Metrics, Projects, Skills } from "@/components/sections";
 
 export default function Home() {
   return (
     <div className="flex w-full flex-col divide-y divide-border">
       <Hero />
+      <Metrics />
       <About />
       <Experience />
       <Projects />


### PR DESCRIPTION
## Summary
- Reposition portfolio as full-stack software engineer (7+ years) with updated hero, about, contact, and page metadata
- Add metrics band and expand experience entries for yetipay, Beacon, Mindera (TVG/FanDuel), and Mindera Academy (concurrent with Beacon)
- Rewrite project copy for business impact and regroup skills to match CV plus microservices, design systems, and AI-assisted engineering
- Change dev/prod server port to 4567 to avoid local port clashes

## Test plan
- [x] `yarn lint`
- [x] Verified hero, metrics, experience, and skills in browser on `http://localhost:4567`
- [x] Review copy for accuracy against CV (dates, role titles, highlights)
- [x] Check light/dark theme and mobile layout on preview deploy