### PR TITLE
feat(analytics): add Vercel Speed Insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@vercel/analytics": "^1.3.1",
+    "@vercel/speed-insights": "^2.0.0",
     "canvas-confetti": "^1.9.4",
     "cmdk": "^1.1.1",
     "lenis": "^1.3.25",

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,5 +1,6 @@
 import { PropsWithChildren, useEffect, useState } from "react";
 import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import { Atkinson_Hyperlegible, Azeret_Mono, Bricolage_Grotesque } from "next/font/google";
 import Head from "next/head";
 import { useRouter } from "next/router";
@@ -99,6 +100,7 @@ export const Layout = ({ children }: PropsWithChildren) => {
       </ThemeProvider>
 
       <Analytics />
+      <SpeedInsights />
     </>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,6 +699,36 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/speed-insights@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@vercel/speed-insights@npm:2.0.0"
+  peerDependencies:
+    "@sveltejs/kit": ^1 || ^2
+    next: ">= 13"
+    nuxt: ">= 3"
+    react: ^18 || ^19 || ^19.0.0-rc
+    svelte: ">= 4"
+    vue: ^3
+    vue-router: ^4
+  peerDependenciesMeta:
+    "@sveltejs/kit":
+      optional: true
+    next:
+      optional: true
+    nuxt:
+      optional: true
+    react:
+      optional: true
+    svelte:
+      optional: true
+    vue:
+      optional: true
+    vue-router:
+      optional: true
+  checksum: 10c0/a8703abcf72f6317183be13a5e991883589c48a8107fedb47d075af08e2d5a71d93e22c1927c8d0c28a69bb0e4712e90386d50947851883b6169c715cd43b4eb
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^5.0.0":
   version: 5.0.0
   resolution: "abbrev@npm:5.0.0"
@@ -4258,6 +4288,7 @@ __metadata:
     "@types/node": "npm:22.2.0"
     "@types/react": "npm:18.3.3"
     "@vercel/analytics": "npm:^1.3.1"
+    "@vercel/speed-insights": "npm:^2.0.0"
     autoprefixer: "npm:10.4.20"
     canvas-confetti: "npm:^1.9.4"
     cmdk: "npm:^1.1.1"


### PR DESCRIPTION
## Summary

- Add `@vercel/speed-insights@2.0.0` dependency
- Mount `<SpeedInsights />` in the shared layout next to existing Vercel Analytics

## Test plan

- [x] `yarn lint` passes
- [x] `yarn build` passes
- [x] Local dev: `/_vercel/speed-insights/script.js` loads in page head; debug mode logs in console
- [ ] Enable Speed Insights in Vercel project dashboard (Speed Insights → Enable)
- [ ] Deploy preview/prod and confirm vitals script on live URL
- [ ] Metrics appear in Vercel Speed Insights dashboard after traffic