### PR TITLE
feat(seo): add bymesc.dev crawl and metadata foundations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Guidance for AI coding agents working in this repository.
 
 ## Project overview
 
-Personal portfolio site for [Marco Escaleira](https://escaleira.dev). A single-page Next.js app with section-based layout (Hero, About, Projects, Experience, Skills, Contact), dark/light theming, smooth scroll, a command palette, and a few easter eggs.
+Personal portfolio site for [Marco Escaleira](https://bymesc.dev). A single-page Next.js app with section-based layout (Hero, About, Projects, Experience, Skills, Contact), dark/light theming, smooth scroll, a command palette, and a few easter eggs.
 
 ## Tech stack
 
@@ -170,7 +170,7 @@ Always consider both when making changes — this is a public portfolio site.
 - **`Layout.tsx`** wraps every page: fonts, theme provider, header/footer, command palette, easter eggs, smooth scroll, analytics.
 - **Command palette** opens via `Cmd/Ctrl+K` or `window.dispatchEvent(new CustomEvent("open-command-palette"))`.
 - **Font variables** are applied to `document.body` because cmdk portals outside the layout tree.
-- **i18n** is configured for `en-US` with domain `escaleira.dev` in `next.config.js`.
+- **i18n** is configured for `en-US` with domain `bymesc.dev` in `next.config.js`.
 - **Images** use `next/image` where applicable.
 
 ## CI/CD

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ module.exports = {
     defaultLocale: 'en-US',
     domains: [
       {
-        domain: 'escaleira.dev',
+        domain: 'bymesc.dev',
         defaultLocale: 'en-US',
       },
     ],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://bymesc.dev/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,25 @@
-{"name":"Escaleira Portfolio","short_name":"","icons":[],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}
+{
+  "name": "Marco Escaleira",
+  "short_name": "bymesc",
+  "icons": [
+    {
+      "src": "/favicon-16x16.png",
+      "sizes": "16x16",
+      "type": "image/png"
+    },
+    {
+      "src": "/favicon-32x32.png",
+      "sizes": "32x32",
+      "type": "image/png"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
+      "type": "image/png"
+    }
+  ],
+  "theme_color": "#0f0e17",
+  "background_color": "#0f0e17",
+  "display": "standalone",
+  "start_url": "/"
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://bymesc.dev/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,6 +11,14 @@ import { GoToTop } from "@/components/GoToTop";
 import { Header, Footer } from "@/components/layout";
 import { SectionNav } from "@/components/SectionNav";
 import { SmoothScroll } from "@/components/SmoothScroll";
+import {
+  SITE_DESCRIPTION,
+  SITE_IMAGE,
+  SITE_NAME,
+  SITE_TITLE,
+  SITE_URL,
+  personJsonLd,
+} from "@/data/site";
 import { useScrollNav } from "@/hooks/useScrollNav";
 
 const atkinson = Atkinson_Hyperlegible({
@@ -68,11 +76,27 @@ export const Layout = ({ children }: PropsWithChildren) => {
   return (
     <>
       <Head>
-        <title>Marco Escaleira — Software Engineer</title>
-        <meta
-          name="description"
-          content="Full-stack software engineer with 7+ years shipping scalable web and mobile products — React, React Native, Node.js, and AWS."
+        <title>{SITE_TITLE}</title>
+        <meta name="description" content={SITE_DESCRIPTION} />
+        <link rel="canonical" href={`${SITE_URL}/`} />
+
+        <meta property="og:type" content="website" />
+        <meta property="og:url" content={`${SITE_URL}/`} />
+        <meta property="og:title" content={SITE_TITLE} />
+        <meta property="og:description" content={SITE_DESCRIPTION} />
+        <meta property="og:image" content={SITE_IMAGE} />
+        <meta property="og:site_name" content={SITE_NAME} />
+
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={SITE_TITLE} />
+        <meta name="twitter:description" content={SITE_DESCRIPTION} />
+        <meta name="twitter:image" content={SITE_IMAGE} />
+
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(personJsonLd) }}
         />
+
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/favicon-16x16.png" sizes="16x16" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/src/components/sections/About.tsx
+++ b/src/components/sections/About.tsx
@@ -34,8 +34,10 @@ export const About = () => {
             className="max-w-prose space-y-md text-fg-muted"
           >
             <p>
-              I grew up in Portugal, studied Computer Science (First-class), and took my first steps as a developer at
-              the Faculty of Medicine in Porto. I taught at Mindera Academy, then moved from Porto to London.
+              I grew up in Portugal and took my first steps as a developer at the Faculty of Medicine in Porto. I
+              moved from Porto to England while already at Mindera — kept shipping software and completed my Honours BSc
+              in Computer Science (First-class) along the way. I later taught at Mindera Academy; these days I&apos;m
+              based in London.
             </p>
             <p>
               I build production-ready products from frontend to backend — owning architecture, infrastructure,

--- a/src/components/sections/Contact.tsx
+++ b/src/components/sections/Contact.tsx
@@ -24,7 +24,7 @@ export const Contact = () => {
         <SectionHeading
           index="05."
           title="Contact"
-          eyebrow="Hiring for full-stack, payments, or production engineering work? My inbox is open."
+          eyebrow="Hiring for full-stack, fintech, or SaaS engineering work? My inbox is open."
         />
 
         <motion.div
@@ -35,8 +35,8 @@ export const Contact = () => {
           className="rounded-lg border border-border bg-surface px-6 py-10 sm:px-10"
         >
           <p className="max-w-prose text-fg-muted">
-            If you&apos;re hiring or building something across web, mobile, or backend — full-stack work with real
-            production ownership — I&apos;d like to hear from you.
+            If you&apos;re hiring or building something in fintech or SaaS — full-stack work with real production
+            ownership across web, mobile, or backend — I&apos;d like to hear from you.
           </p>
 
           <Link

--- a/src/components/sections/Hero.tsx
+++ b/src/components/sections/Hero.tsx
@@ -116,7 +116,7 @@ export const Hero = () => {
           </motion.h1>
 
           <motion.p variants={item} className="mt-md max-w-prose text-lg text-fg-muted sm:text-xl">
-            Full-stack software engineer with 7+ years shipping scalable web and mobile products end to end —
+            Full-stack software engineer with 7+ years shipping fintech and SaaS products end to end —
             React, React Native, Node.js, and AWS — from architecture to production.
           </motion.p>
 

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,6 +1,6 @@
 import { useId, useState } from "react";
 import { ChevronDown, ExternalLink, Github, Globe, Server, Smartphone, Sparkles } from "lucide-react";
-import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
 import { EASE_OUT_EXPO, SectionHeading } from "@/components/sections/SectionHeading";
 import { projects, type Project } from "@/data/projects";
@@ -36,7 +36,7 @@ const ProjectCard = ({ project, isOpen, onToggle }: ProjectCardProps) => {
         type="button"
         onClick={onToggle}
         aria-expanded={isOpen}
-        aria-controls={isOpen ? panelId : undefined}
+        aria-controls={panelId}
         className="group flex w-full items-start justify-between gap-md px-5 py-5 text-left sm:px-6 sm:py-6"
       >
         <div className="min-w-0">
@@ -83,54 +83,50 @@ const ProjectCard = ({ project, isOpen, onToggle }: ProjectCardProps) => {
         </span>
       </button>
 
-      <AnimatePresence initial={false}>
-        {isOpen && (
-          <motion.div
-            id={panelId}
-            key="content"
-            initial={shouldReduceMotion ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
-            animate={{ height: "auto", opacity: 1 }}
-            exit={shouldReduceMotion ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
-            transition={{ duration: shouldReduceMotion ? 0 : 0.35, ease: EASE_OUT_EXPO }}
-            className="overflow-hidden"
-          >
-            <div className="space-y-md border-t border-border px-5 pb-6 pt-5 sm:px-6">
-              <div>
-                <h4 className="font-mono text-xs uppercase tracking-wide text-accent">Problem</h4>
-                <p className="mt-2xs max-w-prose text-sm text-fg-muted">{project.problem}</p>
-              </div>
-              <div>
-                <h4 className="font-mono text-xs uppercase tracking-wide text-accent">What I built</h4>
-                <p className="mt-2xs max-w-prose text-sm text-fg-muted">{project.built}</p>
-              </div>
-              <div>
-                <h4 className="font-mono text-xs uppercase tracking-wide text-accent">Outcome</h4>
-                <p className="mt-2xs max-w-prose text-sm text-fg-muted">{project.outcome}</p>
-              </div>
+      <motion.div
+        id={panelId}
+        initial={false}
+        animate={isOpen ? { height: "auto", opacity: 1 } : { height: 0, opacity: 0 }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.35, ease: EASE_OUT_EXPO }}
+        className="overflow-hidden"
+        aria-hidden={!isOpen}
+      >
+        <div className="space-y-md border-t border-border px-5 pb-6 pt-5 sm:px-6">
+          <div>
+            <h4 className="font-mono text-xs uppercase tracking-wide text-accent">Problem</h4>
+            <p className="mt-2xs max-w-prose text-sm text-fg-muted">{project.problem}</p>
+          </div>
+          <div>
+            <h4 className="font-mono text-xs uppercase tracking-wide text-accent">What I built</h4>
+            <p className="mt-2xs max-w-prose text-sm text-fg-muted">{project.built}</p>
+          </div>
+          <div>
+            <h4 className="font-mono text-xs uppercase tracking-wide text-accent">Outcome</h4>
+            <p className="mt-2xs max-w-prose text-sm text-fg-muted">{project.outcome}</p>
+          </div>
 
-              {availableLinks.length > 0 && (
-                <div className="flex flex-wrap items-center gap-md pt-3xs">
-                  {availableLinks.map(key => {
-                    const { label, icon: Icon } = LINK_META[key];
-                    return (
-                      <Link
-                        key={key}
-                        href={project.links[key] as string}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="flex items-center gap-1.5 text-sm font-medium text-fg transition-colors hover:text-accent"
-                      >
-                        <Icon className="size-4" aria-hidden />
-                        {label}
-                      </Link>
-                    );
-                  })}
-                </div>
-              )}
+          {availableLinks.length > 0 && (
+            <div className="flex flex-wrap items-center gap-md pt-3xs">
+              {availableLinks.map(key => {
+                const { label, icon: Icon } = LINK_META[key];
+                return (
+                  <Link
+                    key={key}
+                    href={project.links[key] as string}
+                    target="_blank"
+                    rel="noreferrer"
+                    tabIndex={isOpen ? undefined : -1}
+                    className="flex items-center gap-1.5 text-sm font-medium text-fg transition-colors hover:text-accent"
+                  >
+                    <Icon className="size-4" aria-hidden />
+                    {label}
+                  </Link>
+                );
+              })}
             </div>
-          </motion.div>
-        )}
-      </AnimatePresence>
+          )}
+        </div>
+      </motion.div>
     </div>
   );
 };

--- a/src/data/experience.ts
+++ b/src/data/experience.ts
@@ -1,5 +1,4 @@
 // Highlights are sourced from Marco's CV summary and are pending Marco's review.
-// TODO(marco): fill exact dates
 export interface Experience {
   company: string;
   role: string;
@@ -69,7 +68,7 @@ export const experience: Experience[] = [
   {
     company: "FMUP (Faculty of Medicine, University of Porto)",
     role: "Early-career developer",
-    period: "",
+    period: "May 2018 – Jul 2018",
     highlights: ["First professional steps — web work that served faculty staff and students"],
   },
 ];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -1,0 +1,38 @@
+export const SITE_URL = "https://bymesc.dev";
+export const SITE_NAME = "Marco Escaleira";
+
+export const SITE_TITLE = "Marco Escaleira — Full-Stack Engineer | Fintech & SaaS";
+
+export const SITE_DESCRIPTION =
+  "Marco Escaleira — full-stack engineer in London building fintech and SaaS products end to end. React, React Native, Node.js, and AWS. Open to hiring conversations.";
+
+export const SITE_IMAGE = `${SITE_URL}/marco.jpg`;
+
+export const PERSON_SAME_AS = [
+  "https://github.com/MarcoEscaleira",
+  "https://www.linkedin.com/in/marco-escaleira00/",
+] as const;
+
+export const PERSON_EMAIL = "marcoescaleira2000@gmail.com";
+
+export const personJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Person",
+  name: SITE_NAME,
+  url: SITE_URL,
+  image: SITE_IMAGE,
+  email: PERSON_EMAIL,
+  jobTitle: "Full-Stack Software Engineer",
+  worksFor: {
+    "@type": "Organization",
+    name: "yetipay",
+    url: "https://yetipay.me",
+  },
+  address: {
+    "@type": "PostalAddress",
+    addressLocality: "London",
+    addressCountry: "GB",
+  },
+  sameAs: [...PERSON_SAME_AS],
+  description: SITE_DESCRIPTION,
+};

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -25,6 +25,7 @@ export default function NotFound() {
     <>
       <Head>
         <title>404 — Marco Escaleira</title>
+        <meta name="robots" content="noindex" />
       </Head>
 
       <div className="flex w-full flex-1 items-center justify-center px-6 py-24">


### PR DESCRIPTION
## Summary
- Point site config and docs at **bymesc.dev** (replacing escaleira.dev)
- Add SEO foundations: `robots.txt`, `sitemap.xml`, canonical URL, Open Graph/Twitter tags, and Person JSON-LD
- Keep project accordion details in the DOM when collapsed so crawlers can index problem/built/outcome copy
- Tune hero and contact copy for full-stack, fintech, and SaaS keywords
- Add `noindex` on 404 and fix `site.webmanifest` name/icons/theme

## Test plan
- [x] `yarn lint` passes
- [x] Local verify: `/robots.txt` and `/sitemap.xml` return 200
- [x] Local verify: title, description, canonical, OG/Twitter, and JSON-LD present in `<head>`
- [x] Local verify: collapsed project cards still render detail content in DOM
- [x] After merge/deploy: spot-check live https://bymesc.dev head tags and crawl files
- [x] After deploy: set up Google Search Console and submit sitemap